### PR TITLE
Fallback to default supervisor in handleFailure

### DIFF
--- a/actor/actor_context.go
+++ b/actor/actor_context.go
@@ -497,7 +497,7 @@ func (ctx *actorContext) handleFailure(msg *Failure) {
 		strategy.HandleFailure(ctx, msg.Who, msg.RestartStats, msg.Reason, msg.Message)
 		return
 	}
-	ctx.props.supervisionStrategy.HandleFailure(ctx, msg.Who, msg.RestartStats, msg.Reason, msg.Message)
+	ctx.props.getSupervisor().HandleFailure(ctx, msg.Who, msg.RestartStats, msg.Reason, msg.Message)
 }
 
 func (ctx *actorContext) stopAllChildren() {


### PR DESCRIPTION
@PotterDai opening this as an extension to https://github.com/AsynkronIT/protoactor-go/pull/291. For cases when a supervisor has not been set explicitly, this makes the fallback `defaultSupervisionStrategy` rather than raising a nil pointer error.