### PR TITLE
[cluster] Errors from the application are not re-tried now

### DIFF
--- a/protobuf/protoc-gen-gograin/template.go
+++ b/protobuf/protoc-gen-gograin/template.go
@@ -54,7 +54,6 @@ func (g *{{ $service.Name }}Grain) {{ $method.Name }}(r *{{ $method.Input.Name }
 
 // {{ $method.Name }}WithOpts requests the execution on to the cluster
 func (g *{{ $service.Name }}Grain) {{ $method.Name }}WithOpts(r *{{ $method.Input.Name }}, opts *cluster.GrainCallOptions) (*{{ $method.Output.Name }}, error) {
-	result := &{{ $method.Output.Name }}{}
 	fun := func() (*{{ $method.Output.Name }}, error) {
 			pid, statusCode := cluster.Get(g.ID, "{{ $service.Name }}")
 			if statusCode != remote.ResponseStatusCodeOK {
@@ -71,15 +70,16 @@ func (g *{{ $service.Name }}Grain) {{ $method.Name }}WithOpts(r *{{ $method.Inpu
 			}
 			switch msg := response.(type) {
 			case *cluster.GrainResponse:
+				result := &{{ $method.Output.Name }}{}
 				err = proto.Unmarshal(msg.MessageData, result)
 				if err != nil {
-					return result, err
+					return nil, err
 				}
 				return result, nil
 			case *cluster.GrainErrorResponse:
-				return result, errors.New(msg.Err)
+				return nil, errors.New(msg.Err)
 			default:
-				return result, errors.New("unknown response")
+				return nil, errors.New("unknown response")
 			}
 		}
 	
@@ -93,7 +93,7 @@ func (g *{{ $service.Name }}Grain) {{ $method.Name }}WithOpts(r *{{ $method.Inpu
 				opts.RetryAction(i)
 		}
 	}
-	return result, err
+	return nil, err
 }
 
 // {{ $method.Name }}Chan allows to use a channel to execute the method using default options

--- a/protobuf/protoc-gen-gograin/template.go
+++ b/protobuf/protoc-gen-gograin/template.go
@@ -88,7 +88,7 @@ func (g *{{ $service.Name }}Grain) {{ $method.Name }}WithOpts(r *{{ $method.Inpu
 	for i := 0; i < opts.RetryCount; i++ {
 		res, err = fun()
 		if err == nil || err.Error() != "future: timeout" {
-			return res, nil
+			return res, err
 		} else if opts.RetryAction != nil {
 				opts.RetryAction(i)
 		}


### PR DESCRIPTION
Hi guys!

I've tweak how the `{{ $method.Name }}WithOpts` is working.
Mainly because it would trigger the `opts.RetryAction` on **any** error.

If the error was a `future: timeout` or a legitimate application error, it would retry it `opts.RetryCount` times.

I don't think that was intended. The retry pattern for requesting data from the actor is solid, it retries if the actor is busy or some networking issue - but if the actor returns an legit error I don't see the point of retrying.

Main change was here:
```
for i := 0; i < opts.RetryCount; i++ {
		res, err = fun()
		if err == nil || err.Error() != "future: timeout" {
			return res, nil
		} else if opts.RetryAction != nil {
				opts.RetryAction(i)
		}
```

It's only retrying it the error is a `future: timeout` - I'm happy to extend to other cluster errors if you guys see fit. Or take some other approach that allows for application errors to go throught the cluster without being retried.


Thanks!
