### PR TITLE
Increase deregister critical interval to 1 minute

### DIFF
--- a/cluster/consul/consul_provider.go
+++ b/cluster/consul/consul_provider.go
@@ -46,7 +46,7 @@ func NewWithConfig(consulConfig *api.Config) (*ConsulProvider, error) {
 		client:             client,
 		ttl:                3 * time.Second,
 		refreshTTL:         1 * time.Second,
-		deregisterCritical: 10 * time.Second,
+		deregisterCritical: 60 * time.Second,
 		blockingWaitTime:   20 * time.Second,
 	}
 	return p, nil


### PR DESCRIPTION
The [consul documentation](https://www.consul.io/docs/agent/checks.html) says:
> In Consul 0.7 and later, checks that are associated with a service may also contain an optional deregister_critical_service_after field, which is a timeout in the same Go time format as interval and ttl. If a check is in the critical state for more than this configured value, then its associated service (and all of its associated checks) will automatically be deregistered. The minimum timeout is 1 minute, and the process that reaps critical services runs every 30 seconds, so it may take slightly longer than the configured timeout to trigger the deregistration. This should generally be configured with a timeout that's much, much longer than any expected recoverable outage for the given service.

That's why we're seeing these warning messages:
```
2019/04/25 16:44:57 [WARN] agent: check 'service:xyz' has deregister interval below minimum of 1m0s
```
That's why this PR just sets the `deregisterCritical` interval to 1 minute per default.

