### PR TITLE
[cluster] Adding PROCESSNAMEALREADYEXIST doesnt seem to be a failure

### DIFF
--- a/protobuf/protoc-gen-gograin/template.go
+++ b/protobuf/protoc-gen-gograin/template.go
@@ -57,7 +57,7 @@ func (g *{{ $service.Name }}Grain) {{ $method.Name }}(r *{{ $method.Input.Name }
 func (g *{{ $service.Name }}Grain) {{ $method.Name }}WithOpts(r *{{ $method.Input.Name }}, opts *cluster.GrainCallOptions) (*{{ $method.Output.Name }}, error) {
 	fun := func() (*{{ $method.Output.Name }}, error) {
 			pid, statusCode := cluster.Get(g.ID, "{{ $service.Name }}")
-			if statusCode != remote.ResponseStatusCodeOK {
+			if statusCode != remote.ResponseStatusCodeOK && statusCode != remote.ResponseStatusCodePROCESSNAMEALREADYEXIST {
 				return nil, fmt.Errorf("get PID failed with StatusCode: %v", statusCode)
 			}
 			bytes, err := proto.Marshal(r)


### PR DESCRIPTION
Will need some review on this one. Not 100% if my interpretation is accurate.

In the cluster template, we have 
```
if statusCode != remote.ResponseStatusCodeOK {
```

Which seems to fail a lot with status code 3 -`ResponseStatusCodePROCESSNAMEALREADYEXIST`

From what I could tell this is a problem in the activator ?
Seems like it's trying to activate something that's already active.

Since the only time this error occurs the pid is returned
```
response := &ActorPidResponse{
				Pid:        pid,
				StatusCode: ResponseStatusCodePROCESSNAMEALREADYEXIST.ToInt32(),
			}
```

I've added to the template as an ignorable error. In my cluster haven't seem more error spikes around Error Code 3.

Sorry for the quick and dry PR, don't have much time today! Thanks!!