### PR TITLE
Resolve data race in internal/queue/mpsc

### DIFF
--- a/internal/queue/mpsc/mpsc.go
+++ b/internal/queue/mpsc/mpsc.go
@@ -38,7 +38,7 @@ func (q *Queue) Push(x interface{}) {
 	prev := (*node)(atomic.SwapPointer((*unsafe.Pointer)(unsafe.Pointer(&q.head)), unsafe.Pointer(n)))
 
 	// release node to consumer
-	prev.next = n
+	atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&prev.next)), unsafe.Pointer(n))
 }
 
 // Pop removes the item from the front of the queue or nil if the queue is empty


### PR DESCRIPTION
Concurrent calls to Push and Pop result in a data race reported by the Go race detector