### PR TITLE
Fixed panic recovery loop #2

### DIFF
--- a/cluster/member_list.go
+++ b/cluster/member_list.go
@@ -106,6 +106,8 @@ func (ml *memberListValue) updateClusterTopology(m interface{}) {
 	}
 }
 
+// updateAndNotify updates the member strategy and notifies all listeners. This function may only be called with an
+// read lock on the event stream.
 func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus) {
 	if new == nil && old == nil {
 		// ignore, not possible
@@ -129,13 +131,13 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: old.Kinds,
 		}
 		left := &MemberLeftEvent{MemberMeta: meta}
-		eventstream.Publish(left)
+		eventstream.PublishUnsafe(left)
 		delete(ml.members, old.Address()) // remove this member as it has left
 
 		rt := &remote.EndpointTerminatedEvent{
 			Address: old.Address(),
 		}
-		eventstream.Publish(rt)
+		eventstream.PublishUnsafe(rt)
 
 		return
 	}
@@ -155,7 +157,7 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		joined := &MemberJoinedEvent{MemberMeta: meta}
-		eventstream.Publish(joined)
+		eventstream.PublishUnsafe(joined)
 
 		return
 	}
@@ -178,7 +180,7 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		joined := &MemberRejoinedEvent{MemberMeta: meta}
-		eventstream.Publish(joined)
+		eventstream.PublishUnsafe(joined)
 
 		return
 	}
@@ -190,7 +192,7 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		unavailable := &MemberUnavailableEvent{MemberMeta: meta}
-		eventstream.Publish(unavailable)
+		eventstream.PublishUnsafe(unavailable)
 
 		return
 	}
@@ -202,6 +204,6 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		available := &MemberAvailableEvent{MemberMeta: meta}
-		eventstream.Publish(available)
+		eventstream.PublishUnsafe(available)
 	}
 }

--- a/cluster/member_list_test.go
+++ b/cluster/member_list_test.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AsynkronIT/protoactor-go/eventstream"
+)
+
+func TestPublishRaceCondition(t *testing.T) {
+	setupMemberList()
+	rounds := 1000
+
+	var wg sync.WaitGroup
+	wg.Add(2 * rounds)
+
+	go func() {
+		for i := 0; i < rounds; i++ {
+			eventstream.Publish(ClusterTopologyEvent([]*MemberStatus{{}, {}}))
+			eventstream.Publish(ClusterTopologyEvent([]*MemberStatus{{}}))
+			wg.Done()
+		}
+	}()
+
+	go func() {
+		for i := 0; i < rounds; i++ {
+			s := eventstream.Subscribe(func(evt interface{}) {})
+			eventstream.Unsubscribe(s)
+			wg.Done()
+		}
+	}()
+
+	if waitTimeout(&wg, 2*time.Second) {
+		t.Error("Should not run into a timeout")
+	}
+}
+
+// https://stackoverflow.com/questions/32840687/timeout-for-waitgroup-wait
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
+	}
+}

--- a/eventstream/eventstream.go
+++ b/eventstream/eventstream.go
@@ -21,6 +21,10 @@ func Publish(event interface{}) {
 	es.Publish(event)
 }
 
+func PublishUnsafe(evt interface{}) {
+	es.PublishUnsafe(evt)
+}
+
 type EventStream struct {
 	sync.RWMutex
 	subscriptions []*Subscription
@@ -68,11 +72,7 @@ func (es *EventStream) Publish(evt interface{}) {
 	es.PublishUnsafe(evt)
 }
 
-func PublishUnsafe(evt interface{}) {
-	es.PublishUnsafe(evt)
-}
-
-func (es *EventStream)  PublishUnsafe(evt interface{}) {
+func (es *EventStream) PublishUnsafe(evt interface{}) {
 	for _, s := range es.subscriptions {
 		if s.p == nil || s.p(evt) {
 			s.fn(evt)

--- a/eventstream/eventstream.go
+++ b/eventstream/eventstream.go
@@ -65,6 +65,14 @@ func (es *EventStream) Publish(evt interface{}) {
 	es.RLock()
 	defer es.RUnlock()
 
+	es.PublishUnsafe(evt)
+}
+
+func PublishUnsafe(evt interface{}) {
+	es.PublishUnsafe(evt)
+}
+
+func (es *EventStream)  PublishUnsafe(evt interface{}) {
 	for _, s := range es.subscriptions {
 		if s.p == nil || s.p(evt) {
 			s.fn(evt)


### PR DESCRIPTION
Another approach to the problem outlined in PR #334:

We're relying on the cluster provider (consul in our case) to reflect a consistent state of the cluster topology. If a node is still part of the cluster (according to consul) we accept the panic/recovery loop, because it could be that it is just temporarily not available. As soon as the cluster provider says that the node has left the cluster the connection attempts are stopped by the `connectionDecider` - a new field on the `remoteConfig`.

In our case the `connectionDecider` checks if the address we're trying to connect to is still part of the cluster. If it is not we stop gracefully.
```go
remotingOption = append(remotingOption, remote.WithConnectionDecider(func(address string) bool {
	adrList := cluster.GetMemberAddresses()
	for _, v := range adrList {
		if v == address {
			return true
		}
	}
	log.Infof("Address %s is no known member. Deciding not to connect", address)
	return false
}))
```

Remarks: 
I would prefer if this logic didn't need to be put in from the outside but rather be handled internally. But we can't have a dependency from the `remote` to the `cluster` package -- This could be solved when the default `ClusterConfig` would have the `connectionDecider` `RemotingOption` already attached to it.
