### PR TITLE
Fix endpoint writer panic recovery loop #3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.0 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.0 // indirect
 	github.com/hashicorp/serf v0.8.2 // indirect
+	github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/orcaman/concurrent-map v0.0.0-20190107190726-7ed82d9cb717

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/hashicorp/memberlist v0.1.3 h1:EmmoJme1matNzb+hMpDuR/0sbJSUisxyqBGG67
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2 h1:YZ7UKsJv+hKjqGVUUbtE3HNj79Eln2oQ75tniF6iPt0=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
+github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7 h1:K//n/AqR5HjG3qxbrBCL4vJPW0MVFSs9CPK1OOJdRME=
+github.com/jpillora/backoff v0.0.0-20180909062703-3050d21c67d7/go.mod h1:2iMrUgbbvHEiQClaW2NsSzMyGHqN+rDFqY705q49KG0=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=


### PR DESCRIPTION
Proposal number 3 to fix the endpoint writer panic loop.

Infos:
* the actor does not `panic` anymore if a connection attempt has failed
* instead it sets its receive timeout and tries to connect again after an exponential backoff
   * the values I chose for the backoff are arbitrary
* the `*actor.ReceiveTimeout` and `*EndpointTerminated` messages ended up in a batch of `[]interface{}` messages and weren't handled by the `Receive` method of the actor directly (only indirectly in the `sendEnvelope` method).
* I added a tiny (100 entries) priority mailbox which gets drained before the user message mailbox and can only contain `*actor.ReceiveTimeout` and `*EndpointTerminated` messages
   * 100 entries is an arbitrary amount and actually I believe already 2 should suffice
* I split the endpoint writer in two behaviors (`Connecting` + `Connected`)
* both behaviors handle `*EndpointTerminated`, so if a member leaves the cluster the actor stops in every case
* The exponential backoff can be interrupted by a new batch of user messages. In this case it tries to reconnect. 
   * If the connection is successfully established the messages are sent by calling `Receive` in `endpoint_writer.go` L177. 
   * If connection establishment was unsuccessful the messages are dropped - The same happens in @Strum355s solution (if I see it right)
  * this does not happen in the current panic/restart loop implementation because the actor only gets to handle system messages - as soon as the actor is connected it drains the user message mailbox

@rogeralsing - I believe the concept of a `connectionDecider` can still be added, but may not be necessary to fix this particular problem