### PR TITLE
Fix nil pointer exception when accessing connections

### DIFF
--- a/remote/endpoint_manager.go
+++ b/remote/endpoint_manager.go
@@ -27,6 +27,7 @@ type endpointManagerValue struct {
 	config             *remoteConfig
 	endpointSupervisor *actor.PID
 	endpointSub        *eventstream.Subscription
+	stopped            bool
 }
 
 func startEndpointManager(config *remoteConfig) {
@@ -60,7 +61,8 @@ func stopEndpointManager() {
 	rootContext.StopFuture(endpointManager.endpointSupervisor).Wait()
 	endpointManager.endpointSub = nil
 	endpointManager.connections = nil
-	plog.Debug("Stopped EndpointManager")
+	endpointManager.stopped = true
+	plog.Info("Stopped EndpointManager")
 }
 
 func (em *endpointManagerValue) endpointEvent(evn interface{}) {

--- a/remote/remote_handler.go
+++ b/remote/remote_handler.go
@@ -3,6 +3,5 @@ package remote
 import "github.com/AsynkronIT/protoactor-go/actor"
 
 func remoteHandler(pid *actor.PID) (actor.Process, bool) {
-	ref := newProcess(pid)
-	return ref, true
+	return newProcess(pid), !endpointManager.stopped
 }


### PR DESCRIPTION
When calling `remote.Shutdown(true)` the function `stopEndpointManager()` sets the `connections` map of the endpoint manager [to nil](https://github.com/AsynkronIT/protoactor-go/blob/630edf9ef64d4b178d0f53ec3bd5ebb0674d207d/remote/endpoint_manager.go#L62). Then we're waiting until the grpc server has shut down. If there is an attempt to send a message to a remote actor in this time interval (between setting the connections map to nil until the server has shut down) we get a nil pointer exception [here](https://github.com/AsynkronIT/protoactor-go/blob/630edf9ef64d4b178d0f53ec3bd5ebb0674d207d/remote/endpoint_manager.go#L101). Our "stacktrace" just shows this though:
```
sync.(*Map).Load:103
```

If we let the remote address resolver return false when the connections map is nil the `ProcessRegistry` will use the [deadletter process as a fallback](https://github.com/AsynkronIT/protoactor-go/blob/630edf9ef64d4b178d0f53ec3bd5ebb0674d207d/actor/process_registry.go#L87). Which is appropriate in my opinion.

_This not yet tested by me_