### PR TITLE
Add coveralls integration settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,24 @@
 language: go
+sudo: false
+
+env:
+  - GO111MODULE=on
+
+git:
+  depth: 1
+
+go:
+  - 1.12.x
+  - 1.13.x
+  - tip
+
+before_script:
+  - go get github.com/mattn/goveralls
+
 script:
-  - env GO111MODULE=on go test ./... -short
+  - go test -v -race -short -coverprofile=coverage.out ./...
+  - $GOPATH/bin/goveralls -coverprofile=coverage.out -service=travis-ci
+
+matrix:
+  allow_failures:
+    - go: tip


### PR DESCRIPTION
Hi, it's my first p-r for this project. I'm a big fan of this project and created several sample repositories and blog posts including [oklahomer/protoactor-go-sender-example](https://github.com/oklahomer/protoactor-go-sender-example).

I've read #348 and mostly agreed with what is being discussed, especially about the importance of tests. However, I found out that .travis.yml does not declare coveralls.io integration even though [coveralls.io setting](https://coveralls.io/github/AsynkronIT/protoactor-go?branch=dev) is half done. This p-r tries to finish some additional .travis.yml settings including target Golang version declaration and coveralls integration.