### PR TITLE
Add tests for remote actors

### DIFF
--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -77,11 +77,7 @@ func Spawn(address, kind string, timeout time.Duration) (*ActorPidResponse, erro
 
 // SpawnNamed spawns a named remote actor of a given type at a given address
 func SpawnNamed(address, name, kind string, timeout time.Duration) (*ActorPidResponse, error) {
-	activator := ActivatorForAddress(address)
-	res, err := rootContext.RequestFuture(activator, &ActorPidRequest{
-		Name: name,
-		Kind: kind,
-	}, timeout).Result()
+	res, err := SpawnFuture(address, name, kind, timeout).Result()
 	if err != nil {
 		return nil, err
 	}

--- a/remote/activator_actor_test.go
+++ b/remote/activator_actor_test.go
@@ -1,0 +1,481 @@
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type ActivatorTestSuite struct {
+	suite.Suite
+}
+
+func (suite *ActivatorTestSuite) SetupTest() {
+	// Initialize package scoped variables
+
+	// from activator_actor.go
+	nameLookup = make(map[string]actor.Props)
+
+	// from actor/process_registry.go
+	actor.ProcessRegistry.RemoteHandlers = []actor.AddressResolver{}
+}
+
+func (suite *ActivatorTestSuite) TearDownTest() {
+	// Reset package scoped variables so those tests run after this test suite won't be affected.
+
+	// from activator_actor.go
+	nameLookup = make(map[string]actor.Props)
+
+	// from actor/process_registry.go
+	actor.ProcessRegistry.RemoteHandlers = []actor.AddressResolver{}
+}
+
+func TestMockedRootContextSuite(t *testing.T) {
+	suite.Run(t, new(ActivatorTestSuite))
+}
+
+func (suite *ActivatorTestSuite) TestSpawnFuture() {
+	name := "name"
+	kind := "kind"
+	address := "192.0.2.0:1234"
+
+	activator, activatorProcess := spawnMockProcess("activator")
+	defer removeMockProcess(activator)
+
+	var resolverCalled = false
+	actor.ProcessRegistry.RemoteHandlers = []actor.AddressResolver{
+		func(pid *actor.PID) (i actor.Process, b bool) {
+			resolverCalled = true
+			suite.Equal("activator", pid.Id)
+			suite.Equal(address, pid.Address)
+			return activatorProcess, true
+		},
+	}
+
+	activatorProcess.On("SendUserMessage", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			var pid *actor.PID
+			if suite.IsType(&actor.PID{}, args.Get(0)) {
+				pid = args.Get(0).(*actor.PID)
+				suite.Equal(activator.Id, pid.Id)
+			}
+
+			var envelope *actor.MessageEnvelope
+			if suite.IsType(&actor.MessageEnvelope{}, args.Get(1)) {
+				envelope = args.Get(1).(*actor.MessageEnvelope)
+				message := envelope.Message
+				if suite.IsType(&ActorPidRequest{}, message) {
+					request := message.(*ActorPidRequest)
+					suite.Equal(name, request.Name)
+					suite.Equal(kind, request.Kind)
+					suite.Equal(address, pid.Address)
+				}
+			}
+
+			// Send the payload back to the sender Future
+			rootContext.Send(envelope.Sender, &ActorPidResponse{
+				Pid: &actor.PID{
+					Address: pid.Address,
+				},
+				StatusCode: ResponseStatusCodeOK.ToInt32(),
+			})
+		}).
+		Once()
+
+	future := SpawnFuture(address, name, kind, 1*time.Second)
+
+	suite.NotNil(future)
+	result, err := future.Result()
+	suite.Nil(err)
+	if suite.IsType(&ActorPidResponse{}, result) {
+		response := result.(*ActorPidResponse)
+		suite.Equal(ResponseStatusCodeOK.ToInt32(), response.StatusCode)
+		suite.Equal(address, response.Pid.GetAddress())
+	}
+
+	suite.True(resolverCalled, "AddressResolver should be called when message is sent over network.")
+}
+
+func (suite *ActivatorTestSuite) TestSpawn() {
+	kind := "kind"
+	address := "192.0.2.0:1234"
+
+	activator, activatorProcess := spawnMockProcess("activator")
+	defer removeMockProcess(activator)
+
+	var resolverCalled = false
+	actor.ProcessRegistry.RemoteHandlers = []actor.AddressResolver{
+		func(pid *actor.PID) (i actor.Process, b bool) {
+			resolverCalled = true
+			suite.Equal("activator", pid.Id)
+			suite.Equal(address, pid.Address)
+			return activatorProcess, true
+		},
+	}
+
+	activatorProcess.On("SendUserMessage", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			var pid *actor.PID
+			if suite.IsType(&actor.PID{}, args.Get(0)) {
+				pid = args.Get(0).(*actor.PID)
+				suite.Equal(activator.Id, pid.Id)
+			}
+
+			var envelope *actor.MessageEnvelope
+			if suite.IsType(&actor.MessageEnvelope{}, args.Get(1)) {
+				envelope = args.Get(1).(*actor.MessageEnvelope)
+				message := envelope.Message
+				if suite.IsType(&ActorPidRequest{}, message) {
+					request := message.(*ActorPidRequest)
+					suite.Empty(request.Name, "No name is given by caller")
+					suite.Equal(kind, request.Kind)
+					suite.Equal(address, pid.Address)
+				}
+			}
+
+			// Send the payload back to the sender Future
+			rootContext.Send(envelope.Sender, &ActorPidResponse{
+				Pid: &actor.PID{
+					Address: pid.Address,
+				},
+				StatusCode: ResponseStatusCodeOK.ToInt32(),
+			})
+		}).
+		Once()
+
+	response, err := Spawn(address, kind, 100*time.Millisecond)
+
+	suite.Nil(err)
+	if suite.NotNil(response) {
+		suite.Equal(ResponseStatusCodeOK.ToInt32(), response.StatusCode)
+		suite.NotNil(response.Pid)
+	}
+
+	suite.True(resolverCalled, "AddressResolver should be called when message is sent over network.")
+}
+
+func (suite *ActivatorTestSuite) TestSpawnNamed() {
+	tests := []struct {
+		Name     string
+		Kind     string
+		Response interface{}
+	}{
+		{
+			Name:     "name",
+			Kind:     "kind",
+			Response: nil, // Underlying Future should timeout
+		},
+		{
+			Name: "name",
+			Kind: "kind",
+			Response: &ActorPidResponse{
+				Pid:        &actor.PID{},
+				StatusCode: ResponseStatusCodeOK.ToInt32(),
+			},
+		},
+		{
+			Name: "name",
+			Kind: "kind",
+			Response: &ActorPidResponse{
+				Pid:        &actor.PID{},
+				StatusCode: ResponseStatusCodePROCESSNAMEALREADYEXIST.ToInt32(),
+			},
+		},
+		{
+			Name: "name",
+			Kind: "kind",
+			Response: &ActorPidResponse{
+				Pid:        nil,
+				StatusCode: ResponseStatusCodeERROR.ToInt32(),
+			},
+		},
+		{
+			Name:     "name",
+			Kind:     "kind",
+			Response: struct{}{}, // Unknown structure is returned
+		},
+	}
+
+	for i, tt := range tests {
+		suite.Run(strconv.Itoa(i), func() {
+			remoteAddress := "192.0.2.0:1234"
+			activator, activatorProcess := spawnMockProcess("activator")
+			defer removeMockProcess(activator)
+
+			var resolverCalled = false
+			actor.ProcessRegistry.RemoteHandlers = []actor.AddressResolver{
+				func(pid *actor.PID) (i actor.Process, b bool) {
+					resolverCalled = true
+					suite.Equal("activator", pid.Id)
+					suite.Equal(remoteAddress, pid.Address)
+					return activatorProcess, true
+				},
+			}
+
+			activatorProcess.On("SendUserMessage", mock.Anything, mock.Anything).
+				Run(func(args mock.Arguments) {
+					var pid *actor.PID
+					if suite.IsType(&actor.PID{}, args.Get(0)) {
+						pid = args.Get(0).(*actor.PID)
+						suite.Equal(activator.Id, pid.Id)
+					}
+
+					var envelope *actor.MessageEnvelope
+					if suite.IsType(&actor.MessageEnvelope{}, args.Get(1)) {
+						envelope = args.Get(1).(*actor.MessageEnvelope)
+						message := envelope.Message
+						if suite.IsType(&ActorPidRequest{}, message) {
+							request := message.(*ActorPidRequest)
+							suite.Equal(tt.Name, request.Name)
+							suite.Equal(tt.Kind, request.Kind)
+						}
+					}
+
+					if tt.Response != nil {
+						// Send the payload back to the sender Future
+						rootContext.Send(envelope.Sender, tt.Response)
+					}
+				}).
+				Once()
+
+			response, err := SpawnNamed(remoteAddress, tt.Name, tt.Kind, 100*time.Millisecond)
+
+			if tt.Response == nil {
+				suite.Equal(actor.ErrTimeout, err)
+				return
+			}
+			switch tt.Response.(type) {
+			case *ActorPidResponse:
+				suite.Equal(tt.Response, response)
+			default:
+				// When non *ActorPidResponse is returned from the underlying Future, that should be converted to an error.
+				suite.Error(err)
+			}
+
+			suite.True(resolverCalled, "AddressResolver should be called when message is sent over network.")
+		})
+	}
+}
+
+func (suite *ActivatorTestSuite) TestRegister() {
+	kind := "target"
+	_, ok := nameLookup[kind]
+	suite.False(ok, "Registering kind already exists: %s", kind)
+
+	props := &actor.Props{}
+	Register(kind, props)
+
+	_, ok = nameLookup[kind]
+	suite.True(ok, "Registered kind is not stored: %s", kind)
+}
+
+func (suite *ActivatorTestSuite) TestGetKnownKinds() {
+	kinds := []string{"target1", "target2"}
+	for _, kind := range kinds {
+		nameLookup[kind] = actor.Props{}
+	}
+
+	knownKinds := GetKnownKinds()
+
+	suite.ElementsMatch(kinds, knownKinds)
+}
+
+func (suite *ActivatorTestSuite) Test_activatorReceive_UnknownKind() {
+	request := &ActorPidRequest{
+		Name: "targetName",
+		Kind: "targetKind",
+	}
+	context := &mockContext{}
+	context.On("Message").Return(request).Once()
+	context.On("Respond", mock.AnythingOfType("*remote.ActorPidResponse")).
+		Run(func(args mock.Arguments) {
+			suite.IsType(&ActorPidResponse{}, args.Get(0))
+			response := args.Get(0).(*ActorPidResponse)
+			suite.Equal(ResponseStatusCodeERROR.ToInt32(), response.StatusCode)
+			suite.Nil(response.Pid)
+		}).
+		Once()
+
+	activator := &activator{}
+	suite.Panics(func() { activator.Receive(context) })
+
+	context.AssertExpectations(suite.T())
+}
+
+func (suite *ActivatorTestSuite) Test_activatorReceive_Spawn() {
+	name := "targetName"
+	kind := "targetKind"
+
+	uncontrollableErr := errors.New("uncontrollable")
+	tests := []struct {
+		TestName string
+		HasKind  bool
+		PidFunc  func(id string) *actor.PID
+		Err      error
+	}{
+		{
+			TestName: "initial call",
+			HasKind:  true,
+			PidFunc: func(id string) *actor.PID {
+				return &actor.PID{
+					Address: "nonhost",
+					Id:      id,
+				}
+			},
+			Err: nil,
+		},
+		{
+			TestName: "subsequent call",
+			HasKind:  true,
+			PidFunc: func(id string) *actor.PID {
+				return &actor.PID{
+					Address: "nonhost",
+					Id:      id,
+				}
+			},
+			Err: actor.ErrNameExists,
+		},
+		{
+			TestName: "activator error",
+			HasKind:  true,
+			PidFunc:  nil,
+			Err: &ActivatorError{
+				Code:       ResponseStatusCodeUNAVAILABLE.ToInt32(),
+				DoNotPanic: false,
+			},
+		},
+		{
+			TestName: "unknown error",
+			HasKind:  true,
+			PidFunc:  nil,
+			Err:      uncontrollableErr,
+		},
+		{
+			TestName: "unknown kind",
+			HasKind:  false,
+			PidFunc:  nil,
+			Err:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		suite.Run(tt.TestName, func() {
+			request := &ActorPidRequest{
+				Name: name,
+				Kind: kind,
+			}
+
+			nameLookup = make(map[string]actor.Props)
+			if tt.HasKind {
+				nameLookup[kind] = *actor.
+					PropsFromFunc(func(c actor.Context) {}).
+					WithSpawnFunc(func(id string, props *actor.Props, parentContext actor.SpawnerContext) (*actor.PID, error) {
+						if tt.PidFunc == nil {
+							return nil, tt.Err
+						}
+						return tt.PidFunc(id), tt.Err
+					})
+			}
+
+			context := &mockContext{}
+			context.On("Message").Return(request).Once() // A request for an actor
+			context.
+				On("Respond", mock.AnythingOfType("*remote.ActorPidResponse")).
+				Run(func(args mock.Arguments) {
+					suite.IsType(&ActorPidResponse{}, args.Get(0))
+					response := args.Get(0).(*ActorPidResponse)
+					if tt.Err != nil {
+						// When an error is returned from spawn func, then the error should be properly translated.
+						switch tt.Err.(type) {
+						case *ActivatorError:
+							suite.Equal(ResponseStatusCodeUNAVAILABLE.ToInt32(), response.StatusCode)
+						default:
+							if tt.Err == actor.ErrNameExists {
+								suite.Equal(ResponseStatusCodePROCESSNAMEALREADYEXIST.ToInt32(), response.StatusCode)
+							} else {
+								suite.Equal(ResponseStatusCodeERROR.ToInt32(), response.StatusCode)
+							}
+						}
+					}
+					if !tt.HasKind {
+						// When no corresponding kind is registered, then the response should contain an error.
+						suite.Equal(ResponseStatusCodeERROR.ToInt32(), response.StatusCode)
+					}
+					if tt.PidFunc != nil {
+						suite.NotNil(response.Pid)
+						suite.Equal(actor.ProcessRegistry.Address, response.Pid.GetAddress())
+						suite.Contains(response.Pid.GetId(), name)
+						suite.Equal(fmt.Sprintf("Remote$%s", name), response.Pid.Id)
+					}
+				}).
+				Once()
+
+			e, ok := tt.Err.(*ActivatorError)
+			if (ok && !e.DoNotPanic) ||
+				tt.Err == uncontrollableErr ||
+				!tt.HasKind {
+
+				activator := &activator{}
+				suite.Panics(func() {
+					activator.Receive(context)
+				})
+				context.AssertExpectations(suite.T())
+				return
+			}
+
+			activator := &activator{}
+			activator.Receive(context)
+			context.AssertExpectations(suite.T())
+		})
+	}
+
+	suite.Run("ignorable message", func() {
+		ignorables := []interface{}{
+			&actor.Started{},
+			&actor.Stopped{},
+			&actor.Restart{},
+			&actor.Failure{},
+			&actor.Terminated{},
+			&actor.Watch{},
+			&actor.Unwatch{},
+			&actor.PoisonPill{},
+			&actor.Restarting{},
+			&actor.Stopping{},
+			&actor.Restarting{},
+			struct{}{}, // Unknown type of message
+		}
+
+		for _, msg := range ignorables {
+			suite.Run(fmt.Sprintf("%T", msg), func() {
+				context := &mockContext{}
+				context.On("Message").Return(msg).Once()
+
+				activator := &activator{}
+				activator.Receive(context)
+
+				// Message is ignored and hence Respond is not called
+				context.AssertNotCalled(suite.T(), "Respond")
+				context.AssertExpectations(suite.T())
+			})
+		}
+	})
+}
+
+func TestActivatorError_Error(t *testing.T) {
+	var code int32 = 123
+	err := &ActivatorError{Code: code}
+	assert.Contains(t, err.Error(), fmt.Sprint(code), "Error message should contain stringified form of code")
+}
+
+func TestActivatorForAddress(t *testing.T) {
+	address := "192.0.2.0"
+	pid := ActivatorForAddress(address)
+	assert.Equal(t, address, pid.Address)
+}

--- a/remote/common_test.go
+++ b/remote/common_test.go
@@ -1,0 +1,202 @@
+package remote
+
+import (
+	"fmt"
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// mockContext
+type mockContext struct {
+	mock.Mock
+}
+
+//
+// Interface: Context
+//
+func (m *mockContext) Stop(pid *actor.PID) {
+	m.Called()
+}
+
+func (m *mockContext) StopFuture(pid *actor.PID) *actor.Future {
+	args := m.Called()
+	return args.Get(0).(*actor.Future)
+}
+
+func (m *mockContext) Poison(pid *actor.PID) {
+	m.Called()
+}
+
+func (m *mockContext) PoisonFuture(pid *actor.PID) *actor.Future {
+	args := m.Called()
+	return args.Get(0).(*actor.Future)
+}
+
+func (m *mockContext) Parent() *actor.PID {
+	args := m.Called()
+	return args.Get(0).(*actor.PID)
+}
+
+func (m *mockContext) Self() *actor.PID {
+	args := m.Called()
+	return args.Get(0).(*actor.PID)
+}
+
+func (m *mockContext) Sender() *actor.PID {
+	args := m.Called()
+	return args.Get(0).(*actor.PID)
+}
+
+func (m *mockContext) Actor() actor.Actor {
+	args := m.Called()
+	return args.Get(0).(actor.Actor)
+}
+
+func (m *mockContext) ReceiveTimeout() time.Duration {
+	args := m.Called()
+	return args.Get(0).(time.Duration)
+}
+
+func (m *mockContext) Children() []*actor.PID {
+	args := m.Called()
+	return args.Get(0).([]*actor.PID)
+}
+
+func (m *mockContext) Respond(response interface{}) {
+	m.Called(response)
+}
+
+func (m *mockContext) Stash() {
+	m.Called()
+}
+
+func (m *mockContext) Watch(pid *actor.PID) {
+	m.Called(pid)
+}
+
+func (m *mockContext) Unwatch(pid *actor.PID) {
+	m.Called(pid)
+}
+
+func (m *mockContext) SetReceiveTimeout(d time.Duration) {
+	m.Called(d)
+}
+
+func (m *mockContext) CancelReceiveTimeout() {
+	m.Called()
+}
+
+func (m *mockContext) Forward(pid *actor.PID) {
+	m.Called()
+}
+
+func (m *mockContext) AwaitFuture(f *actor.Future, cont func(res interface{}, err error)) {
+	m.Called(f, cont)
+}
+
+//
+// Interface: SenderContext
+//
+
+func (m *mockContext) Message() interface{} {
+	args := m.Called()
+	return args.Get(0)
+}
+
+func (m *mockContext) MessageHeader() actor.ReadonlyMessageHeader {
+	args := m.Called()
+	return args.Get(0).(actor.ReadonlyMessageHeader)
+}
+
+func (m *mockContext) Send(pid *actor.PID, message interface{}) {
+	m.Called()
+}
+
+func (m *mockContext) Request(pid *actor.PID, message interface{}) {
+	args := m.Called()
+	p, _ := actor.ProcessRegistry.Get(pid)
+	env := &actor.MessageEnvelope{
+		Header:  nil,
+		Message: message,
+		Sender:  args.Get(0).(*actor.PID),
+	}
+	p.SendUserMessage(pid, env)
+}
+
+func (m *mockContext) RequestWithCustomSender(pid *actor.PID, message interface{}, sender *actor.PID) {
+	m.Called()
+	p, _ := actor.ProcessRegistry.Get(pid)
+	env := &actor.MessageEnvelope{
+		Header:  nil,
+		Message: message,
+		Sender:  sender,
+	}
+	p.SendUserMessage(pid, env)
+}
+
+func (m *mockContext) RequestFuture(pid *actor.PID, message interface{}, timeout time.Duration) *actor.Future {
+	args := m.Called()
+	return args.Get(0).(*actor.Future)
+}
+
+//
+// Interface: ReceiverContext
+//
+
+func (m *mockContext) Receive(envelope *actor.MessageEnvelope) {
+	m.Called(envelope)
+}
+
+//
+// Interface: SpawnerContext
+//
+
+func (m *mockContext) Spawn(p *actor.Props) *actor.PID {
+	args := m.Called(p)
+	return args.Get(0).(*actor.PID)
+}
+
+func (m *mockContext) SpawnPrefix(p *actor.Props, prefix string) *actor.PID {
+	args := m.Called(p, prefix)
+	return args.Get(0).(*actor.PID)
+}
+
+func (m *mockContext) SpawnNamed(p *actor.Props, name string) (*actor.PID, error) {
+	args := m.Called(p, name)
+	return args.Get(0).(*actor.PID), args.Get(1).(error)
+}
+
+// mockProcess
+type mockProcess struct {
+	mock.Mock
+}
+
+func spawnMockProcess(name string) (*actor.PID, *mockProcess) {
+	p := &mockProcess{}
+	pid, ok := actor.ProcessRegistry.Add(p, name)
+	if !ok {
+		panic(fmt.Errorf("did not spawn named process '%s'", name))
+	}
+
+	return pid, p
+}
+
+func removeMockProcess(pid *actor.PID) {
+	actor.ProcessRegistry.Remove(pid)
+}
+
+func (m *mockProcess) SendUserMessage(pid *actor.PID, message interface{}) {
+	m.Called(pid, message)
+}
+
+func (m *mockProcess) SendSystemMessage(pid *actor.PID, message interface{}) {
+	m.Called(pid, message)
+}
+
+func (m *mockProcess) Stop(pid *actor.PID) {
+	m.Called(pid)
+}
+
+var _ actor.Context = (*mockContext)(nil)

--- a/remote/server.go
+++ b/remote/server.go
@@ -2,7 +2,6 @@ package remote
 
 import (
 	"io/ioutil"
-	slog "log"
 	"net"
 	"os"
 	"time"
@@ -23,7 +22,7 @@ var rootContext = actor.EmptyRootContext
 
 // Start the remote server
 func Start(address string, options ...RemotingOption) {
-	grpclog.SetLogger(slog.New(ioutil.Discard, "", 0))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 	lis, err := net.Listen("tcp", address)
 	if err != nil {
 		plog.Error("failed to listen", log.Error(err))

--- a/remote/server_test.go
+++ b/remote/server_test.go
@@ -1,0 +1,226 @@
+package remote
+
+import (
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/AsynkronIT/protoactor-go/eventstream"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"google.golang.org/grpc"
+)
+
+type ServerTestSuite struct {
+	suite.Suite
+	originalProcessRegistry *actor.ProcessRegistryValue
+}
+
+func (suite *ServerTestSuite) SetupTest() {
+	// Initialize package scoped variables
+
+	// from server.go
+	s = nil
+	edpReader = nil
+
+	// from activator_actor.go
+	activatorPid = nil
+
+	// from endpoint_manager.go
+	endpointManager = nil
+}
+
+func (suite *ServerTestSuite) TearDownTest() {
+	if s != nil {
+		s.Stop() // Stop currently running gRPC server
+	}
+
+	// Reset package scoped variables so those tests run after this test suite won't be affected.
+
+	// from server.go
+	s = nil
+	edpReader = nil
+
+	// from activator_actor.go
+	activatorPid = nil
+
+	// from endpoint_manager.go
+	endpointManager = nil
+}
+
+func TestServerSuite(t *testing.T) {
+	suite.Run(t, new(ServerTestSuite))
+}
+
+func (suite *ServerTestSuite) TestStart() {
+	// Find available port
+	lis, err := net.Listen("tcp", "127.0.0.1:0") // use :0 to choose available port
+	if err != nil {
+		panic(err)
+	}
+	address := lis.Addr()
+	lis.Close()
+
+	optionCalled := false
+	Start(address.String(), func(_ *remoteConfig) {
+		optionCalled = true
+	})
+
+	suite.True(optionCalled, "Passed RemoteOption should be called")
+	suite.NotEmpty(actor.ProcessRegistry.RemoteHandlers, "AddressResolver should be registered on server start")
+	suite.Equal(address.String(), actor.ProcessRegistry.Address)
+	suite.NotNil(activatorPid, "Activator actor should be initialized on server start")
+	suite.NotNil(endpointManager, "EndpointManager should be initialized on server start")
+	suite.NotNil(edpReader, "EndpointReader should be initialized on server start")
+	suite.NotNil(s, "gRPC server should be started on server start")
+}
+
+func (suite *ServerTestSuite) TestStart_AdvertisedAddress() {
+	// Find available port
+	lis, err := net.Listen("tcp", "127.0.0.1:0") // use :0 to choose available port
+	if err != nil {
+		panic(err)
+	}
+	address := lis.Addr()
+	lis.Close()
+
+	advertisedAddress := "192.0.2.1:1234"
+	Start(address.String(), WithAdvertisedAddress(advertisedAddress))
+
+	suite.NotEmpty(actor.ProcessRegistry.RemoteHandlers, "AddressResolver should be registered on server start")
+	suite.Equal(advertisedAddress, actor.ProcessRegistry.Address, "WithAdvertisedAddress should have higher priority")
+	suite.NotNil(activatorPid, "Activator actor should be initialized on server start")
+	suite.NotNil(endpointManager, "EndpointManager should be initialized on server start")
+	suite.Equal(advertisedAddress, endpointManager.config.advertisedAddress, "Passed configuration option should be used")
+	suite.NotNil(edpReader, "EndpointReader should be initialized on server start")
+	suite.NotNil(s, "gRPC server should be started on server start")
+}
+
+func (suite *ServerTestSuite) TestShutdown_Graceful() {
+	edpReader = &endpointReader{}
+	suite.False(edpReader.suspended, "EndpointReader should not be suspended at beginning")
+
+	endpointSupervisor, endpointSupervisorProcess := spawnMockProcess("EndpointSupervisor")
+	defer removeMockProcess(endpointSupervisor)
+	endpointSupervisorProcess.On("SendSystemMessage", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			if suite.IsType(&actor.PID{}, args.Get(0)) {
+				pid := args.Get(0).(*actor.PID)
+				suite.Equal(endpointSupervisor, pid)
+			}
+			if suite.IsType(&actor.Watch{}, args.Get(1)) {
+				watch := args.Get(1).(*actor.Watch)
+				actor.EmptyRootContext.Send(watch.Watcher, &actor.Terminated{
+					Who:               endpointSupervisor,
+					AddressTerminated: false,
+				})
+			}
+		}).
+		Once()
+	endpointSupervisorProcess.On("Stop", endpointSupervisor).Once()
+
+	endpointManager = &endpointManagerValue{
+		connections:        &sync.Map{},
+		config:             nil,
+		endpointSupervisor: endpointSupervisor,
+		endpointSub:        eventstream.Subscribe(func(evt interface{}) {}),
+	}
+
+	var activatorProcess *mockProcess
+	activatorPid, activatorProcess = spawnMockProcess("activator")
+	defer removeMockProcess(activatorPid)
+	activatorProcess.On("SendSystemMessage", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			if suite.IsType(&actor.PID{}, args.Get(0)) {
+				pid := args.Get(0).(*actor.PID)
+				suite.Equal(activatorPid, pid)
+			}
+			if suite.IsType(&actor.Watch{}, args.Get(1)) {
+				watch := args.Get(1).(*actor.Watch)
+				actor.EmptyRootContext.Send(watch.Watcher, &actor.Terminated{
+					Who:               activatorPid,
+					AddressTerminated: false,
+				})
+			}
+		}).
+		Once()
+	activatorProcess.On("Stop", activatorPid).Once()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0") // use :0 to choose available port
+	if err != nil {
+		panic(err)
+	}
+	defer lis.Close()
+
+	grpcStopped := make(chan struct{}, 1)
+	s = grpc.NewServer()
+	go func() {
+		s.Serve(lis)
+		grpcStopped <- struct{}{}
+	}()
+
+	Shutdown(true)
+
+	suite.Nil(endpointManager.endpointSub, "Subscription should reset on shutdown")
+	suite.Nil(endpointManager.connections, "Connections should reset on shutdown")
+
+	select {
+	case <-time.NewTimer(15 * time.Second).C:
+		suite.FailNow("gRPC server did not stop")
+	case <-grpcStopped:
+		// O.K.
+	}
+
+	endpointSupervisorProcess.AssertExpectations(suite.T())
+}
+
+func (suite *ServerTestSuite) TestShutdown() {
+	edpReader = &endpointReader{}
+	suite.False(edpReader.suspended, "EndpointReader should not be suspended at beginning")
+
+	endpointSupervisor, endpointSupervisorProcess := spawnMockProcess("EndpointSupervisor")
+	defer removeMockProcess(endpointSupervisor)
+
+	var activatorProcess *mockProcess
+	activatorPid, activatorProcess = spawnMockProcess("activator")
+	defer removeMockProcess(activatorPid)
+
+	endpointManager = &endpointManagerValue{
+		connections:        &sync.Map{},
+		config:             nil,
+		endpointSupervisor: endpointSupervisor,
+		endpointSub:        eventstream.Subscribe(func(evt interface{}) {}),
+	}
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0") // use :0 to choose available port
+	if err != nil {
+		panic(err)
+	}
+	defer lis.Close()
+
+	grpcStopped := make(chan struct{}, 1)
+	s = grpc.NewServer()
+	go func() {
+		s.Serve(lis)
+		grpcStopped <- struct{}{}
+	}()
+
+	Shutdown(false)
+
+	suite.NotNil(endpointManager.endpointSub, "Subscription should not reset on non-graceful shutdown")
+	suite.NotNil(endpointManager.connections, "Connections should not reset on non-graceful shutdown")
+
+	select {
+	case <-time.NewTimer(1 * time.Second).C:
+		suite.FailNow("gRPC server did not stop")
+	case <-grpcStopped:
+		// O.K.
+	}
+
+	activatorProcess.AssertNotCalled(suite.T(), "SendSystemMessage", mock.Anything, mock.Anything)
+	activatorProcess.AssertExpectations(suite.T())
+	endpointSupervisorProcess.AssertNotCalled(suite.T(), "SendSystemMessage", mock.Anything, mock.Anything)
+	endpointSupervisorProcess.AssertExpectations(suite.T())
+}


### PR DESCRIPTION
Following #357, this is a trial to have better test coverage. Since its aim is to make sure the current logic works as expected and to prevent having undesirable side effects in future modification, its modification does not contain many changes to the current codebase. However, as parts of refactoring, this work contains some minor changes introduced in a86b920 and 
5df75ed.
Being not sure if this course of action is welcomed by all collaborators, this only contains some tests on core functions as a trial. Please feel free to reject if another approach is preferred. I hope this supports #348 to release v1 in the near future.