### PR TITLE
Removing the KVs usage from consul

### DIFF
--- a/cluster/consul/consul_provider.go
+++ b/cluster/consul/consul_provider.go
@@ -63,11 +63,6 @@ func (p *ConsulProvider) RegisterMember(clusterName string, address string, port
 		return err
 	}
 
-	err = p.registerMember()
-	if err != nil {
-		return err
-	}
-
 	// IMPORTANT: do these ops sync directly after registering.
 	// this will ensure that the local node sees its own information upon startup.
 
@@ -86,11 +81,6 @@ func (p *ConsulProvider) RegisterMember(clusterName string, address string, port
 
 func (p *ConsulProvider) DeregisterMember() error {
 	err := p.deregisterService()
-	if err != nil {
-		fmt.Println(err)
-		return err
-	}
-	err = p.deregisterMember()
 	if err != nil {
 		fmt.Println(err)
 		return err
@@ -138,13 +128,6 @@ func (p *ConsulProvider) UpdateTTL() {
 				continue
 			}
 
-			err = p.registerMember()
-			if err != nil {
-				log.Println("[CLUSTER] [CONSUL] Error reregistering member", err)
-				time.Sleep(p.refreshTTL)
-				continue
-			}
-
 			log.Println("[CLUSTER] [CONSUL] Reregistered service in consul")
 			time.Sleep(p.refreshTTL)
 		}
@@ -156,12 +139,7 @@ func (p *ConsulProvider) UpdateMemberStatusValue(statusValue cluster.MemberStatu
 	if p.statusValue == nil {
 		return nil
 	}
-	kvKey := fmt.Sprintf("%v/%v:%v/StatusValue", p.clusterName, p.address, p.port)
-	_, err := p.client.KV().Put(&api.KVPair{
-		Key:   kvKey,
-		Value: p.statusValueSerializer.ToValueBytes(p.statusValue), // currently, just a semi unique id for this member
-	}, &api.WriteOptions{})
-	return err
+	return nil
 }
 
 func (p *ConsulProvider) blockingUpdateTTL() error {
@@ -188,38 +166,6 @@ func (p *ConsulProvider) deregisterService() error {
 	return p.client.Agent().ServiceDeregister(p.id)
 }
 
-func (p *ConsulProvider) registerMember() error {
-	txn := api.KVTxnOps{}
-
-	// register a unique ID for the current process
-	// similar to UID for Akka ActorSystem
-	// TODO: Orleans just use an int32 for the unique id called Generation.
-	kvKey := fmt.Sprintf("%v/%v:%v/ID", p.clusterName, p.address, p.port)
-	txn = append(txn, &api.KVTxnOp{
-		Verb:  api.KVSet,
-		Key:   kvKey,
-		Value: []byte(time.Now().UTC().Format(time.RFC3339)),
-	})
-
-	if p.statusValue != nil {
-		statusValueKey := fmt.Sprintf("%v/%v:%v/StatusValue", p.clusterName, p.address, p.port)
-		txn = append(txn, &api.KVTxnOp{
-			Verb:  api.KVSet,
-			Key:   statusValueKey,
-			Value: p.statusValueSerializer.ToValueBytes(p.statusValue),
-		})
-	}
-
-	_, _, _, err := p.client.KV().Txn(txn, &api.QueryOptions{})
-	return err
-}
-
-func (p *ConsulProvider) deregisterMember() error {
-	kvKey := fmt.Sprintf("%v/%v:%v", p.clusterName, p.address, p.port)
-	_, err := p.client.KV().DeleteTree(kvKey, &api.WriteOptions{})
-	return err
-}
-
 // call this directly after registering the service
 func (p *ConsulProvider) blockingStatusChange() {
 	p.notifyStatuses()
@@ -236,23 +182,11 @@ func (p *ConsulProvider) notifyStatuses() {
 	}
 	p.index = meta.LastIndex
 
-	// fetch additional info per member from the consul KV store
-	kvKey := p.clusterName + "/"
-	kv, _, err := p.client.KV().List(kvKey, &api.QueryOptions{})
-	if err != nil {
-		log.Printf("Error %v", err)
-		return
-	}
-	kvMap := make(map[string][]byte)
-	for _, v := range kv {
-		kvMap[v.Key] = v.Value
-	}
-
 	res := make(cluster.ClusterTopologyEvent, len(statuses))
 	for i, v := range statuses {
 		key := fmt.Sprintf("%v/%v:%v", p.clusterName, v.Service.Address, v.Service.Port)
-		memberID := string(kvMap[key+"/ID"])
-		memberStatusVal := p.statusValueSerializer.FromValueBytes(kvMap[key+"/StatusValue"])
+		memberID := key
+		memberStatusVal := p.statusValueSerializer.FromValueBytes([]byte(key))
 		ms := &cluster.MemberStatus{
 			MemberID:    memberID,
 			Host:        v.Service.Address,

--- a/cluster/consul/consul_provider_test.go
+++ b/cluster/consul/consul_provider_test.go
@@ -39,3 +39,46 @@ func TestRefreshMemberTTL(t *testing.T) {
 	})
 	time.Sleep(60 * time.Second)
 }
+
+func TestRegisterMultipleMembers(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	members := []struct{
+		cluster string
+		address string
+		port int
+	} {
+		{"mycluster2", "127.0.0.1", 8001 },
+		{"mycluster2", "127.0.0.1", 8002 },
+		{"mycluster2", "127.0.0.1", 8003 },
+	}
+
+	p, _ := New()
+	defer p.Shutdown()
+
+	for _, member := range members {
+		err := p.RegisterMember(member.cluster, member.address, member.port, []string{"a", "b"}, nil, &cluster.NilMemberStatusValueSerializer{})
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	entries, _, err := p.client.Health().Service("mycluster2", "", true, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	found := false
+	for _, entry := range entries {
+		found = false
+		for _, member := range members {
+			if entry.Service.Port == member.port {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Member port not found - ID:%v Address: %v:%v \n", entry.Service.ID, entry.Service.Address, entry.Service.Port)
+		}
+	}
+}


### PR DESCRIPTION
Hi !

We've been tackling an issue where the grains try to connect to non-existing instances of silos.
This seems to work - would like to have a review from you guys, I might be missing something :)

# Breakdown of the problem
- Multiple instances of silos connect lets say addresses/IDs: (X,Y,Z)
- Instances register with consul as service - MyCluster
- Instances ask consul to store some more data in the form of K/V pairs
- Instances list the keys and from those they assert which silos exist
- MyCluster is now 1 service with 3 instances (X, Y, Z) and 3 K/V pairs
(problem)
- We kill all 3 instances and restart them on different addresses (A,B,C)
- Instances register with consul as a service - MyCluster
- Instances ask consul to store some more data in the form of K/V pairs
- Instances list the keys and from those they assert which silos exist
Now this brings back 6 KV (A,B,C,X,Y,Z) because there was never a cleanup of the KV.
- The problem then continues on because there is no instance that can clean up the KV values of X,Y,Z

# Fix
Stop using the KV.
Instead use the health endpoint and get the address from the Service, leaving Consul to manage available ones.

# Caveat 
- I'm not sure what we want from K/V pairs
- Not sure of the purpose of the `memberStatusVal` here: https://github.com/AsynkronIT/protoactor-go/blob/e7cc7b4f4be0bd4c6343a1a2ca39854db8dcdd65/cluster/consul/consul_provider.go#L255

Thanks! :)