### PR TITLE
Endpoint actor now doesn't crashloop

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1171,6 +1171,7 @@ github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5/go.mod h1:uVHyebswE1cCXr2A73cRM2frx5ld1RJUCJkFNZ90ZiI=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=

--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -1,8 +1,6 @@
 package remote
 
 import (
-	"time"
-
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/eventstream"
 	"github.com/AsynkronIT/protoactor-go/log"
@@ -27,15 +25,13 @@ type endpointWriter struct {
 	defaultSerializerId int32
 }
 
-func (state *endpointWriter) initialize() {
+func (state *endpointWriter) initialize() error {
 	err := state.initializeInternal()
 	if err != nil {
 		plog.Error("EndpointWriter failed to connect", log.String("address", state.address), log.Error(err))
-		// Wait 2 seconds to restart and retry
-		// Replace with Exponential Backoff
-		time.Sleep(2 * time.Second)
-		panic(err)
+		return err
 	}
+	return nil
 }
 
 func (state *endpointWriter) initializeInternal() error {
@@ -157,7 +153,14 @@ func addToLookup(m map[string]int32, name string, a []string) (int32, []string) 
 func (state *endpointWriter) Receive(ctx actor.Context) {
 	switch msg := ctx.Message().(type) {
 	case *actor.Started:
-		state.initialize()
+		err := state.initialize()
+		if err != nil {
+			plog.Error("Endpoint could not reach endpoint address - killing endpoint actor",
+				log.Error(err),
+				log.String("actorId", ctx.Self().GetId()),
+				log.String("actorAddress", ctx.Self().GetAddress()))
+			ctx.Stop(ctx.Self())
+		}
 	case *actor.Stopped:
 		state.conn.Close()
 	case *actor.Restarting:


### PR DESCRIPTION
Removing the panic as it would only keep the Endpoint writer trying to connect to an address that did not exist anymore.
Instead it returns an error and stops the actor - instead of panic + restart forever.

This has been a major bug in our cluster that would require a total restart of the cluster node. 
Very happy to have caught it 😃 



