### PR TITLE
Adding an Automanaged Cluster package

### DIFF
--- a/cluster/automanaged/automanaged_provider.go
+++ b/cluster/automanaged/automanaged_provider.go
@@ -1,0 +1,390 @@
+package automanaged
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/net/context"
+
+	"github.com/AsynkronIT/protoactor-go/cluster"
+	"github.com/AsynkronIT/protoactor-go/eventstream"
+	"github.com/AsynkronIT/protoactor-go/log"
+	"github.com/labstack/echo"
+	"golang.org/x/sync/errgroup"
+)
+
+var (
+	plog                       = log.New(log.DebugLevel, "[CLUSTER] [AUTOMANAGED]")
+	clusterTTLErrorMutex       = new(sync.Mutex)
+	clusterMonitorErrorMutex   = new(sync.Mutex)
+	shutdownMutex              = new(sync.Mutex)
+	deregisteredMutex          = new(sync.Mutex)
+	activeProviderMutex        = new(sync.Mutex)
+	activeProviderRunningMutex = new(sync.Mutex)
+)
+
+type AutoManagedProvider struct {
+	deregistered          bool
+	shutdown              bool
+	activeProvider        *echo.Echo
+	activeProviderRunning bool
+	activeProviderTesting bool
+	httpClient            *http.Client
+	monitoringStatus      bool
+	clusterName           string
+	address               string
+	autoManagePort        int
+	memberPort            int
+	knownKinds            []string
+	knownNodes            []*NodeModel
+	hosts                 []string
+	refreshTTL            time.Duration
+	statusValue           cluster.MemberStatusValue
+	statusValueSerializer cluster.MemberStatusValueSerializer
+	clusterTTLError       error
+	clusterMonitorError   error
+}
+
+// New creates a AutoManagedProvider that connects locally
+func New() *AutoManagedProvider {
+	return NewWithConfig(
+		2*time.Second,
+		6330,
+		"localhost:6330",
+	)
+}
+
+// NewWithConfig creates an Automanaged Provider that connects to a all the hosts
+func NewWithConfig(refreshTTL time.Duration, autoManPort int, hosts ...string) *AutoManagedProvider {
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 5 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       90 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		MaxConnsPerHost:       10,
+	}
+
+	httpClient := &http.Client{
+		Transport: transport,
+		Timeout:   2 * time.Second,
+	}
+
+	p := &AutoManagedProvider{
+		hosts:                 hosts,
+		httpClient:            httpClient,
+		refreshTTL:            refreshTTL,
+		autoManagePort:        autoManPort,
+		activeProviderRunning: false,
+		monitoringStatus:      false,
+	}
+
+	return p
+}
+
+// NewWithTesting creates a testable provider
+func NewWithTesting(refreshTTL time.Duration, autoManPort int, activeProvider *echo.Echo, hosts ...string) *AutoManagedProvider {
+	p := NewWithConfig(refreshTTL, autoManPort, hosts...)
+	p.activeProviderTesting = true
+	p.activeProvider = activeProvider
+
+	return p
+}
+
+func (p *AutoManagedProvider) RegisterMember(clusterName string, address string, port int, knownKinds []string,
+	statusValue cluster.MemberStatusValue, serializer cluster.MemberStatusValueSerializer) error {
+	p.clusterName = clusterName
+	p.address = address
+	p.memberPort = port
+	p.knownKinds = knownKinds
+	p.statusValue = statusValue
+	p.statusValueSerializer = serializer
+	p.deregistered = false
+	p.shutdown = false
+
+	p.UpdateTTL()
+	return nil
+}
+
+// DeregisterMember set the shutdown to true preventing any more TTL updates
+func (p *AutoManagedProvider) DeregisterMember() error {
+	deregisteredMutex.Lock()
+	defer deregisteredMutex.Unlock()
+
+	p.deregistered = true
+	return nil
+}
+
+// Shutdown set the shutdown to true preventing any more TTL updates
+func (p *AutoManagedProvider) Shutdown() error {
+	shutdownMutex.Lock()
+	defer shutdownMutex.Unlock()
+
+	p.shutdown = true
+	p.activeProvider.Close()
+	return nil
+}
+
+// UpdateTTL sets up an endpoint to respond to other members
+func (p *AutoManagedProvider) UpdateTTL() {
+	activeProviderRunningMutex.Lock()
+	running := p.activeProviderRunning
+	activeProviderRunningMutex.Unlock()
+
+	if (p.isShutdown() || p.isDeregistered()) && running {
+		p.activeProvider.Close()
+		return
+	}
+
+	if running {
+		return
+	}
+
+	// its not running and its not shutdown or deregistered
+	// its also not a test (this should be refactored)
+
+	if !p.activeProviderTesting {
+		p.activeProvider = echo.New()
+		p.activeProvider.HideBanner = true
+		p.activeProvider.GET("/_health", func(context echo.Context) error {
+			return context.JSON(http.StatusOK, p.getCurrentNode())
+		})
+	}
+
+	go func() {
+
+		activeProviderRunningMutex.Lock()
+		p.activeProviderRunning = true
+		activeProviderRunningMutex.Unlock()
+
+		appURI := fmt.Sprintf("0.0.0.0:%d", p.autoManagePort)
+		plog.Error("Automanaged server stopping..!", log.Error(p.activeProvider.Start(appURI)))
+
+		activeProviderRunningMutex.Lock()
+		p.activeProviderRunning = false
+		activeProviderRunningMutex.Unlock()
+	}()
+}
+
+func (p *AutoManagedProvider) UpdateMemberStatusValue(statusValue cluster.MemberStatusValue) error {
+	p.statusValue = statusValue
+	if p.statusValue == nil {
+		return nil
+	}
+	return nil
+}
+
+// MonitorMemberStatusChanges creates a go routine that continuously checks other members
+func (p *AutoManagedProvider) MonitorMemberStatusChanges() {
+	if !p.monitoringStatus {
+		go func() {
+			for !p.isShutdown() && !p.isDeregistered() {
+				p.monitorStatuses()
+			}
+		}()
+	}
+	p.monitoringStatus = true
+}
+
+// GetHealthStatus returns an error if the cluster health status has problems
+func (p *AutoManagedProvider) GetHealthStatus() error {
+	var err error
+	clusterTTLErrorMutex.Lock()
+	clusterMonitorErrorMutex.Lock()
+	defer clusterMonitorErrorMutex.Unlock()
+	defer clusterTTLErrorMutex.Unlock()
+
+	if p.clusterTTLError != nil {
+		err = fmt.Errorf("TTL: %s", p.clusterTTLError.Error())
+	}
+
+	if p.clusterMonitorError != nil {
+		if err != nil {
+			err = fmt.Errorf("%s - Monitor: %s", err.Error(), p.clusterMonitorError.Error())
+		}
+		err = fmt.Errorf("Monitor: %s", p.clusterMonitorError.Error())
+	}
+
+	return err
+}
+
+//
+// Private methods
+//
+
+// monitorStatuses checks for node changes in the cluster
+func (p *AutoManagedProvider) monitorStatuses() {
+	clusterMonitorErrorMutex.Lock()
+	defer clusterMonitorErrorMutex.Unlock()
+
+	autoManagedNodes, err := p.checkNodes()
+	if err != nil && len(autoManagedNodes) == 0 {
+		plog.Error("Failure reaching nodes", log.Error(err))
+		p.clusterMonitorError = err
+		time.Sleep(p.refreshTTL)
+		return
+	}
+
+	// we should probably check if the cluster needs to be updated..
+	var res cluster.ClusterTopologyEvent
+	var newNodes []*NodeModel
+	for _, node := range autoManagedNodes {
+		if node == nil || node.ClusterName != p.clusterName {
+			continue
+		}
+		key := node.ID
+		memberID := key
+		memberStatusVal := p.statusValueSerializer.Deserialize(key)
+		ms := &cluster.MemberStatus{
+			MemberID:    memberID,
+			Host:        node.Address,
+			Port:        node.Port,
+			Kinds:       node.Kinds,
+			Alive:       true,
+			StatusValue: memberStatusVal,
+		}
+		res = append(res, ms)
+		newNodes = append(newNodes, node)
+	}
+
+	p.knownNodes = newNodes
+	p.clusterMonitorError = nil
+	// publish the current cluster topology onto the event stream
+	eventstream.Publish(res)
+	time.Sleep(p.refreshTTL)
+
+}
+
+// checkNodes pings all the nodes and returns the new cluster topology
+func (p *AutoManagedProvider) checkNodes() ([]*NodeModel, error) {
+
+	allNodes := make([]*NodeModel, len(p.hosts))
+	g, _ := errgroup.WithContext(context.Background())
+
+	for indice, nodeHost := range p.hosts {
+
+		idx, el := indice, nodeHost // https://golang.org/doc/faq#closures_and_goroutines
+
+		// Calling go funcs to execute the node check
+		g.Go(func() error {
+
+			url := fmt.Sprintf("http://%s/_health", el)
+			req, err := http.NewRequest("GET", url, nil)
+			if err != nil {
+				plog.Error("Couldn't request node health status", log.Error(err), log.String("autoManMemberUrl", url))
+				return err
+			}
+
+			resp, err := p.httpClient.Do(req)
+			if err != nil {
+				plog.Error("Bad connection to the node health status", log.Error(err), log.String("autoManMemberUrl", url))
+				return err
+			}
+
+			defer resp.Body.Close() // nolint: errcheck
+
+			if resp.StatusCode != http.StatusOK {
+				err = fmt.Errorf("non 200 status returned: %d - from node: %s", resp.StatusCode, el)
+				plog.Error("Bad response from the node health status", log.Error(err), log.String("autoManMemberUrl", url))
+				return err
+			}
+
+			var node *NodeModel
+			err = json.NewDecoder(resp.Body).Decode(&node)
+			if err != nil {
+				err = fmt.Errorf("could not deserialize response: %v - from node: %s", resp, el)
+				plog.Error("Bad data from the node health status", log.Error(err), log.String("autoManMemberUrl", url))
+				return err
+			}
+
+			allNodes[idx] = node
+			return nil
+		})
+	}
+
+	// waits until all functions have returned
+	err := g.Wait()
+	retNodes := []*NodeModel{}
+
+	// clear out the nil ones
+	for _, node := range allNodes {
+		if node != nil {
+			retNodes = append(retNodes, node)
+		}
+	}
+
+	return retNodes, err
+}
+
+func (p *AutoManagedProvider) deregisterService() {
+	deregisteredMutex.Lock()
+	defer deregisteredMutex.Unlock()
+
+	p.deregistered = true
+}
+
+func (p *AutoManagedProvider) startActiveProvider() {
+	activeProviderRunningMutex.Lock()
+	running := p.activeProviderRunning
+	activeProviderRunningMutex.Unlock()
+
+	if !running {
+
+		if !p.activeProviderTesting {
+			p.activeProvider = echo.New()
+			p.activeProvider.HideBanner = true
+			p.activeProvider.GET("/_health", func(context echo.Context) error {
+				return context.JSON(http.StatusOK, p.getCurrentNode())
+			})
+		}
+
+		appURI := fmt.Sprintf("0.0.0.0:%d", p.autoManagePort)
+
+		go func() {
+
+			activeProviderRunningMutex.Lock()
+			p.activeProviderRunning = true
+			activeProviderRunningMutex.Unlock()
+
+			plog.Error("Automanaged server stopping..!", log.Error(p.activeProvider.Start(appURI)))
+
+			activeProviderRunningMutex.Lock()
+			p.activeProviderRunning = false
+			activeProviderRunningMutex.Unlock()
+		}()
+	}
+}
+
+func (p *AutoManagedProvider) stopActiveProvider() {
+	p.activeProvider.Close()
+
+}
+
+func (p *AutoManagedProvider) isShutdown() bool {
+	shutdownMutex.Lock()
+	defer shutdownMutex.Unlock()
+	return p.shutdown
+}
+
+func (p *AutoManagedProvider) isDeregistered() bool {
+	deregisteredMutex.Lock()
+	defer deregisteredMutex.Unlock()
+	return p.deregistered
+}
+
+func (p *AutoManagedProvider) isActiveProviderRunning() bool {
+	activeProviderRunningMutex.Lock()
+	defer activeProviderRunningMutex.Unlock()
+	return p.activeProviderRunning
+}
+
+func (p *AutoManagedProvider) getCurrentNode() *NodeModel {
+	return NewNode(p.clusterName, p.address, p.memberPort, p.autoManagePort, p.knownKinds)
+}

--- a/cluster/automanaged/automanaged_provider_test.go
+++ b/cluster/automanaged/automanaged_provider_test.go
@@ -1,0 +1,179 @@
+package automanaged
+
+import (
+	"log"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo"
+
+	"github.com/AsynkronIT/protoactor-go/cluster"
+)
+
+var (
+	mockData = new(sync.Mutex)
+)
+
+// TestRegisterMember tests a basic member registration and TTL update
+func TestRegisterMember(t *testing.T) {
+
+	clusterName := "mycluster"
+	clusterAddress := "localhost"
+	clusterPort := 8181
+	kinds := []string{"a", "b"}
+
+	p := New()
+	defer p.Shutdown()
+	err := p.RegisterMember(clusterName, clusterAddress, clusterPort, kinds, nil, &cluster.NilMemberStatusValueSerializer{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	time.Sleep(2 * time.Second)
+	err = p.GetHealthStatus()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p.MonitorMemberStatusChanges()
+	time.Sleep(5 * time.Second)
+	err = p.GetHealthStatus()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// TestErrorRegister tests an error registering a member
+func TestErrorRegister(t *testing.T) {
+
+	clusterName := "mycluster"
+	clusterAddress := "127.0.0.1"
+	clusterPort := 8181
+	autoManPort := 6330
+	kinds := []string{"a", "b"}
+
+	callMock := CallMocker{}
+
+	e := echo.New()
+	e.HideBanner = true
+	defer e.Close()
+
+	callMock.setMockData(http.StatusBadRequest, nil)
+	e.GET("/_health", func(context echo.Context) error {
+		return context.JSON(callMock.getMockData())
+	})
+
+	p := NewWithTesting(2*time.Second, 6330, e, "localhost:6330")
+	defer p.Shutdown()
+
+	err := p.RegisterMember(clusterName, clusterAddress, clusterPort, kinds, nil, &cluster.NilMemberStatusValueSerializer{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	time.Sleep(2 * time.Second)
+	err = p.GetHealthStatus()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p.MonitorMemberStatusChanges()
+	time.Sleep(2 * time.Second)
+	err = p.GetHealthStatus()
+	if err == nil {
+		log.Fatal(err)
+	}
+
+	node := NewNode(clusterName, clusterAddress, clusterPort, autoManPort, kinds)
+	callMock.setMockData(http.StatusOK, node)
+
+	time.Sleep(2 * time.Second)
+	err = p.GetHealthStatus()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	e.Close()
+	time.Sleep(2 * time.Second)
+	err = p.GetHealthStatus()
+	if err == nil {
+		log.Fatal(err)
+	}
+
+}
+
+// TestDiffCluster tests when registering members from diff clusters
+func TestDiffCluster(t *testing.T) {
+
+	clusterName1 := "mycluster"
+	clusterAddress1 := "127.0.0.1"
+	clusterPort1 := 8181
+	kinds1 := []string{"a", "b"}
+
+	p := New()
+	defer p.Shutdown()
+	err := p.RegisterMember(clusterName1, clusterAddress1, clusterPort1, kinds1, nil, &cluster.NilMemberStatusValueSerializer{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	time.Sleep(2 * time.Second)
+	err = p.GetHealthStatus()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p.MonitorMemberStatusChanges()
+	time.Sleep(3 * time.Second)
+	err = p.GetHealthStatus()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	clusterName2 := "mycluster2"
+	clusterAddress2 := "127.0.0.1"
+	clusterPort2 := 8282
+	kinds2 := []string{"a", "b"}
+
+	p2 := New()
+	defer p2.Shutdown()
+	err = p2.RegisterMember(clusterName2, clusterAddress2, clusterPort2, kinds2, nil, &cluster.NilMemberStatusValueSerializer{})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	time.Sleep(2 * time.Second)
+	err = p2.GetHealthStatus()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	p2.MonitorMemberStatusChanges()
+	time.Sleep(3 * time.Second)
+	err = p2.GetHealthStatus()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+type CallMocker struct {
+	httpCode int
+	data     interface{}
+}
+
+func (c *CallMocker) getMockData() (code int, i interface{}) {
+	mockData.Lock()
+	defer mockData.Unlock()
+
+	return c.httpCode, c.data
+}
+
+func (c *CallMocker) setMockData(code int, i interface{}) {
+	mockData.Lock()
+	defer mockData.Unlock()
+
+	c.httpCode = code
+	c.data = i
+}

--- a/cluster/automanaged/node_model.go
+++ b/cluster/automanaged/node_model.go
@@ -1,0 +1,29 @@
+package automanaged
+
+import "fmt"
+
+// NodeModel represents a node in the cluster
+type NodeModel struct {
+	ID             string   `json:"id"`
+	Address        string   `json:"address"`
+	AutoManagePort int      `json:"auto_manage_port"`
+	Port           int      `json:"port"`
+	Kinds          []string `json:"kinds"`
+	ClusterName    string   `json:"cluster_name"`
+}
+
+// NewNode returns a new node for the cluster
+func NewNode(clusterName string, address string, port int, autoManPort int, kind []string) *NodeModel {
+	return &NodeModel{
+		ID:             createNodeID(clusterName, address, port),
+		ClusterName:    clusterName,
+		Address:        address,
+		Port:           port,
+		AutoManagePort: autoManPort,
+		Kinds:          kind,
+	}
+}
+
+func createNodeID(clusterName string, address string, port int) string {
+	return fmt.Sprintf("%v@%v:%v", clusterName, address, port)
+}

--- a/examples/cluster-broadcast/node1/main.go
+++ b/examples/cluster-broadcast/node1/main.go
@@ -2,28 +2,37 @@ package main
 
 import (
 	"fmt"
-	"github.com/AsynkronIT/goconsole"
+	"time"
+
+	console "github.com/AsynkronIT/goconsole"
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/cluster"
-	"github.com/AsynkronIT/protoactor-go/cluster/consul"
+	"github.com/AsynkronIT/protoactor-go/cluster/automanaged"
 	"github.com/AsynkronIT/protoactor-go/examples/cluster-broadcast/shared"
 	"github.com/AsynkronIT/protoactor-go/remote"
-	"log"
-	"time"
 )
 
-func main () {
+func main() {
 	startNode(8080)
 
 	fmt.Print("\nBoot other nodes and press Enter\n")
 	console.ReadLine()
+
+	fmt.Print("\nAdding 1 Egg - Enter\n")
+	console.ReadLine()
 	calcAdd("Eggs", 1)
+
+	fmt.Print("\nAdding 10 Egg - Enter\n")
+	console.ReadLine()
 	calcAdd("Eggs", 10)
 
-	calcAdd("Bananas", 1000)
+	fmt.Print("\nAdding 100 Bananas - Enter\n")
+	console.ReadLine()
+	calcAdd("Bananas", 100)
 
+	fmt.Print("\nAdding 2 Meat - Enter\n")
+	console.ReadLine()
 	calcAdd("Meat", 3)
-	calcAdd("Meat", 9000)
 
 	getAll()
 
@@ -32,7 +41,7 @@ func main () {
 	cluster.Shutdown(true)
 }
 
-func startNode(port int64)  {
+func startNode(port int64) {
 	// how long before the grain poisons itself
 	timeout := 10 * time.Minute
 
@@ -58,16 +67,14 @@ func startNode(port int64)  {
 		return &shared.TrackGrain{}
 	})
 
-	cp, err := consul.New()
-	if err != nil {
-		log.Fatal(err)
-	}
-	cluster.Start("mycluster", fmt.Sprintf("127.0.0.1:%v", port), cp)
+	clusterProvider := automanaged.NewWithConfig(2*time.Second, 6330, "localhost:6330", "localhost:6331")
+
+	cluster.Start("mycluster", fmt.Sprintf("localhost:%v", port), clusterProvider)
 }
 
-func calcAdd(grainId string, addNumber int64)  {
+func calcAdd(grainId string, addNumber int64) {
 	calcGrain := shared.GetCalculatorGrain(grainId)
-	total1, err := calcGrain.Add(&shared.NumberRequest{ Number: addNumber})
+	total1, err := calcGrain.Add(&shared.NumberRequest{Number: addNumber})
 	if err != nil {
 		panic(err)
 	}
@@ -75,7 +82,7 @@ func calcAdd(grainId string, addNumber int64)  {
 	fmt.Printf("Grain: %v - Total: %v \n", calcGrain.ID, total1.Number)
 }
 
-func getAll()  {
+func getAll() {
 	trackerGrain := shared.GetTrackerGrain("singleTrackerGrain")
 	totals, err := trackerGrain.BroadcastGetCounts(&shared.Noop{})
 	if err != nil {

--- a/examples/cluster-broadcast/node2/main.go
+++ b/examples/cluster-broadcast/node2/main.go
@@ -2,29 +2,37 @@ package main
 
 import (
 	"fmt"
-	"github.com/AsynkronIT/goconsole"
+	"time"
+
+	console "github.com/AsynkronIT/goconsole"
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/cluster"
-	"github.com/AsynkronIT/protoactor-go/cluster/consul"
+	"github.com/AsynkronIT/protoactor-go/cluster/automanaged"
 	"github.com/AsynkronIT/protoactor-go/examples/cluster-broadcast/shared"
 	"github.com/AsynkronIT/protoactor-go/remote"
-	"log"
-	"time"
 )
 
-func main () {
+func main() {
 	startNode(8081)
 
 	fmt.Print("\nBoot other nodes and press Enter\n")
 	console.ReadLine()
 
+	fmt.Print("\nAdding 1 Egg - Enter\n")
+	console.ReadLine()
 	calcAdd("Eggs", 1)
+
+	fmt.Print("\nAdding 10 Egg - Enter\n")
+	console.ReadLine()
 	calcAdd("Eggs", 10)
 
-	calcAdd("Bananas", 1000)
+	fmt.Print("\nAdding 100 Bananas - Enter\n")
+	console.ReadLine()
+	calcAdd("Bananas", 100)
 
+	fmt.Print("\nAdding 2 Meat - Enter\n")
+	console.ReadLine()
 	calcAdd("Meat", 3)
-	calcAdd("Meat", 9000)
 
 	getAll()
 
@@ -33,7 +41,7 @@ func main () {
 	cluster.Shutdown(true)
 }
 
-func startNode(port int64)  {
+func startNode(port int64) {
 	// how long before the grain poisons itself
 	timeout := 10 * time.Minute
 
@@ -59,16 +67,13 @@ func startNode(port int64)  {
 		return &shared.TrackGrain{}
 	})
 
-	cp, err := consul.New()
-	if err != nil {
-		log.Fatal(err)
-	}
-	cluster.Start("mycluster", fmt.Sprintf("127.0.0.1:%v", port), cp)
+	clusterProvider := automanaged.NewWithConfig(2*time.Second, 6331, "localhost:6330", "localhost:6331")
+	cluster.Start("mycluster", fmt.Sprintf("localhost:%v", port), clusterProvider)
 }
 
-func calcAdd(grainId string, addNumber int64)  {
+func calcAdd(grainId string, addNumber int64) {
 	calcGrain := shared.GetCalculatorGrain(grainId)
-	total1, err := calcGrain.Add(&shared.NumberRequest{ Number: addNumber})
+	total1, err := calcGrain.Add(&shared.NumberRequest{Number: addNumber})
 	if err != nil {
 		panic(err)
 	}
@@ -76,7 +81,7 @@ func calcAdd(grainId string, addNumber int64)  {
 	fmt.Printf("Grain: %v - Total: %v \n", calcGrain.ID, total1.Number)
 }
 
-func getAll()  {
+func getAll() {
 	trackerGrain := shared.GetTrackerGrain("singleTrackerGrain")
 	totals, err := trackerGrain.BroadcastGetCounts(&shared.Noop{})
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,8 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20190923154419-df201c70410d // indirect
 	github.com/imdario/mergo v0.3.8 // indirect
 	github.com/joyent/triton-go v1.7.0 // indirect
+	github.com/labstack/echo v3.3.10+incompatible
+	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/linode/linodego v0.12.0 // indirect
 	github.com/mitchellh/hashstructure v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
@@ -70,6 +72,7 @@ require (
 	go.opencensus.io v0.22.2 // indirect
 	golang.org/x/crypto v0.0.0-20191117063200-497ca9f6d64f // indirect
 	golang.org/x/net v0.0.0-20191116160921-f9c825593386
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191118013547-6254a7c3cac6 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	google.golang.org/api v0.14.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1025,6 +1025,10 @@ github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
+github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
+github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
+github.com/labstack/gommon v0.3.0 h1:JEeO0bvc78PKdyHxloTKiF8BD5iGrH8T6MSeGvSgob0=
+github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
@@ -1082,6 +1086,7 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
+github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.10 h1:qxFzApOv4WsAL965uUPIsXzAKCZxN2p9UqdhFS4ZW10=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -1171,6 +1176,7 @@ github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/openzipkin-contrib/zipkin-go-opentracing v0.3.5/go.mod h1:uVHyebswE1cCXr2A73cRM2frx5ld1RJUCJkFNZ90ZiI=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
@@ -1397,6 +1403,10 @@ github.com/unrolled/secure v0.0.0-20181022170031-4b6b7cf51606/go.mod h1:mnPT77IA
 github.com/unrolled/secure v0.0.0-20190103195806-76e6d4e9b90c/go.mod h1:mnPT77IAdsi/kV7+Es7y+pXALeV3h7G6dQF6mNYjcLA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.0.1 h1:tY9CJiPnMXf1ERmG2EyK7gNUd+c6RKGD0IfU8WdUSz8=
+github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/vmware/govmomi v0.18.0 h1:f7QxSmP7meCtoAmiKZogvVbLInT+CZx6Px6K5rYsJZo=
 github.com/vmware/govmomi v0.18.0/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=
 github.com/vmware/govmomi v0.21.0 h1:jc8uMuxpcV2xMAA/cnEDlnsIjvqcMra5Y8onh/U3VuY=


### PR DESCRIPTION
This is a package that can be used for the cluster management instead of using Consul.

In short: 
- There's a hardcoded fixed list of members
- Each member has that list
- Each member pings that list and updates the cluster topology
- Each member has an open http port where he reports his information (alive, kinds, etc)

Simple enough for what we use - we have a k8s cluster with 10 pods where we were not getting much from consul.
Additionally there are some issues with consul that would inevitably hit the protoactor cluster.
I decided to get rid of consul and limit our exposure to issues.

With this packaged and the https://github.com/AsynkronIT/protoactor-go/pull/369 we now have more reliant cluster.
Before, if a pod would restart (change IP) the cluster would go bananas on errors and some actors would never respond again (PR https://github.com/AsynkronIT/protoactor-go/pull/369 ). 
Additionally if the consul pods would have problems electing a leader or *any* kind of problem the cluster would go bananas again. Reducing the risk seems to be the right choice - for now anyways 😅 

Happy to discuss this further! 😃 
