### PR TITLE
Fix deadlock when (un)subscribing from/to the eventstream

### DIFF
--- a/cluster/member_list.go
+++ b/cluster/member_list.go
@@ -106,6 +106,8 @@ func (ml *memberListValue) updateClusterTopology(m interface{}) {
 	}
 }
 
+// updateAndNotify updates the member strategy and notifies all listeners. This function may only be called with an
+// read lock on the event stream.
 func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus) {
 	if new == nil && old == nil {
 		// ignore, not possible
@@ -129,13 +131,13 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: old.Kinds,
 		}
 		left := &MemberLeftEvent{MemberMeta: meta}
-		eventstream.Publish(left)
+		eventstream.PublishUnsafe(left)
 		delete(ml.members, old.Address()) // remove this member as it has left
 
 		rt := &remote.EndpointTerminatedEvent{
 			Address: old.Address(),
 		}
-		eventstream.Publish(rt)
+		eventstream.PublishUnsafe(rt)
 
 		return
 	}
@@ -155,7 +157,7 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		joined := &MemberJoinedEvent{MemberMeta: meta}
-		eventstream.Publish(joined)
+		eventstream.PublishUnsafe(joined)
 
 		return
 	}
@@ -178,7 +180,7 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		joined := &MemberRejoinedEvent{MemberMeta: meta}
-		eventstream.Publish(joined)
+		eventstream.PublishUnsafe(joined)
 
 		return
 	}
@@ -190,7 +192,7 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		unavailable := &MemberUnavailableEvent{MemberMeta: meta}
-		eventstream.Publish(unavailable)
+		eventstream.PublishUnsafe(unavailable)
 
 		return
 	}
@@ -202,6 +204,6 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		available := &MemberAvailableEvent{MemberMeta: meta}
-		eventstream.Publish(available)
+		eventstream.PublishUnsafe(available)
 	}
 }

--- a/cluster/member_list_test.go
+++ b/cluster/member_list_test.go
@@ -1,0 +1,52 @@
+package cluster
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AsynkronIT/protoactor-go/eventstream"
+)
+
+func TestPublishRaceCondition(t *testing.T) {
+	setupMemberList()
+	rounds := 1000
+
+	var wg sync.WaitGroup
+	wg.Add(2 * rounds)
+
+	go func() {
+		for i := 0; i < rounds; i++ {
+			eventstream.Publish(ClusterTopologyEvent([]*MemberStatus{{}, {}}))
+			eventstream.Publish(ClusterTopologyEvent([]*MemberStatus{{}}))
+			wg.Done()
+		}
+	}()
+
+	go func() {
+		for i := 0; i < rounds; i++ {
+			s := eventstream.Subscribe(func(evt interface{}) {})
+			eventstream.Unsubscribe(s)
+			wg.Done()
+		}
+	}()
+
+	if waitTimeout(&wg, 2*time.Second) {
+		t.Error("Should not run into a timeout")
+	}
+}
+
+// https://stackoverflow.com/questions/32840687/timeout-for-waitgroup-wait
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
+	}
+}

--- a/eventstream/eventstream.go
+++ b/eventstream/eventstream.go
@@ -21,6 +21,10 @@ func Publish(event interface{}) {
 	es.Publish(event)
 }
 
+func PublishUnsafe(evt interface{}) {
+	es.PublishUnsafe(evt)
+}
+
 type EventStream struct {
 	sync.RWMutex
 	subscriptions []*Subscription
@@ -68,11 +72,7 @@ func (es *EventStream) Publish(evt interface{}) {
 	es.PublishUnsafe(evt)
 }
 
-func PublishUnsafe(evt interface{}) {
-	es.PublishUnsafe(evt)
-}
-
-func (es *EventStream)  PublishUnsafe(evt interface{}) {
+func (es *EventStream) PublishUnsafe(evt interface{}) {
 	for _, s := range es.subscriptions {
 		if s.p == nil || s.p(evt) {
 			s.fn(evt)

--- a/eventstream/eventstream.go
+++ b/eventstream/eventstream.go
@@ -65,6 +65,14 @@ func (es *EventStream) Publish(evt interface{}) {
 	es.RLock()
 	defer es.RUnlock()
 
+	es.PublishUnsafe(evt)
+}
+
+func PublishUnsafe(evt interface{}) {
+	es.PublishUnsafe(evt)
+}
+
+func (es *EventStream)  PublishUnsafe(evt interface{}) {
 	for _, s := range es.subscriptions {
 		if s.p == nil || s.p(evt) {
 			s.fn(evt)


### PR DESCRIPTION
This PR introduces the method `eventstream.PublishUnsafe` which does not acquire the read lock on the eventstream.

When a `ClusterTopologyEvent` is published on the event stream the emitter of this event has acquired a read lock to the event stream. As an effect of this event another call to `eventstream.Publish` is **synchronously** made in `updateAndNotify` further down the chain. So a second read lock gets acquired (`eventstream/eventstream.goL65`)

When right in between both of those two read locks another write lock wants to be made we end up in a dead lock. The order of events:
* read lock gets acquired
* write lock -> waits until first read lock is released
* second read lock -> waits until the write lock is released

That the second read lock waits for the write lock is an implementation detail of the `sync.RWMutex` `RLock` method:
```go
// RLock locks rw for reading.
//
// It should not be used for recursive read locking; a blocked Lock
// call excludes new readers from acquiring the lock. See the
// documentation on the RWMutex type.
func (rw *RWMutex) RLock() {
	if race.Enabled {
		_ = rw.w.state
		race.Disable()
	}
	if atomic.AddInt32(&rw.readerCount, 1) < 0 {
		// A writer is pending, wait for it.          <-------
		runtime_SemacquireMutex(&rw.readerSem, false, 0)
	}
	if race.Enabled {
		race.Enable()
		race.Acquire(unsafe.Pointer(&rw.readerSem))
	}
}
```
Source: https://golang.org/src/sync/rwmutex.go

It is safe to use the `PublishUnsafe` method in `updateAndNotify` because it is synchronously made as a result of the `ClusterTopologyEvent`.

The given test proves that there was a deadlock. When the `PublishUnsafe` methods are replaced with the regular `Publish` methods we run into a timeout.