### PR TITLE
Fix empty MemberStatusValues in consul cluster provider #374

### DIFF
--- a/cluster/consul/consul_provider.go
+++ b/cluster/consul/consul_provider.go
@@ -190,7 +190,7 @@ func (p *ConsulProvider) notifyStatuses() {
 	for i, v := range statuses {
 		key := fmt.Sprintf("%v/%v:%v", p.clusterName, v.Service.Address, v.Service.Port)
 		memberID := key
-		memberStatusVal := p.statusValueSerializer.Deserialize(v.Node.Meta["StatusValue"])
+		memberStatusVal := p.statusValueSerializer.Deserialize(v.Service.Meta["StatusValue"])
 		ms := &cluster.MemberStatus{
 			MemberID:    memberID,
 			Host:        v.Service.Address,


### PR DESCRIPTION
Instead of reading from the node metadata the consul cluster provider
now reads the serialized MemberStatusValue from consul's service metadata where it was already being written to.