### PR TITLE
Use cmap instead of array/mutex for Subscriptions in EventStream

### DIFF
--- a/cluster/member_list.go
+++ b/cluster/member_list.go
@@ -131,13 +131,13 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: old.Kinds,
 		}
 		left := &MemberLeftEvent{MemberMeta: meta}
-		eventstream.PublishUnsafe(left)
+		eventstream.Publish(left)
 		delete(ml.members, old.Address()) // remove this member as it has left
 
 		rt := &remote.EndpointTerminatedEvent{
 			Address: old.Address(),
 		}
-		eventstream.PublishUnsafe(rt)
+		eventstream.Publish(rt)
 
 		return
 	}
@@ -157,7 +157,7 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		joined := &MemberJoinedEvent{MemberMeta: meta}
-		eventstream.PublishUnsafe(joined)
+		eventstream.Publish(joined)
 
 		return
 	}
@@ -180,7 +180,7 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		joined := &MemberRejoinedEvent{MemberMeta: meta}
-		eventstream.PublishUnsafe(joined)
+		eventstream.Publish(joined)
 
 		return
 	}
@@ -192,7 +192,7 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		unavailable := &MemberUnavailableEvent{MemberMeta: meta}
-		eventstream.PublishUnsafe(unavailable)
+		eventstream.Publish(unavailable)
 
 		return
 	}
@@ -204,6 +204,6 @@ func (ml *memberListValue) updateAndNotify(new *MemberStatus, old *MemberStatus)
 			Kinds: new.Kinds,
 		}
 		available := &MemberAvailableEvent{MemberMeta: meta}
-		eventstream.PublishUnsafe(available)
+		eventstream.Publish(available)
 	}
 }

--- a/cluster/member_list_test.go
+++ b/cluster/member_list_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestPublishRaceCondition(t *testing.T) {
 	setupMemberList()
-	rounds := 1000
+	rounds := 400
 
 	var wg sync.WaitGroup
 	wg.Add(2 * rounds)
@@ -31,7 +31,7 @@ func TestPublishRaceCondition(t *testing.T) {
 		}
 	}()
 
-	if waitTimeout(&wg, 2*time.Second) {
+	if waitTimeout(&wg, 10*time.Second) {
 		t.Error("Should not run into a timeout")
 	}
 }

--- a/eventstream/eventstream.go
+++ b/eventstream/eventstream.go
@@ -47,10 +47,13 @@ func (es *EventStream) Unsubscribe(sub *Subscription) {
 }
 
 func (es *EventStream) Publish(evt interface{}) {
-	for iter := range es.subscriptions.Iter() {
-		s, ok := iter.Val.(*Subscription)
-		if ok && (s.p == nil || s.p(evt)) {
-			s.fn(evt)
+	for _, key := range es.subscriptions.Keys() {
+		i, ok := es.subscriptions.Get(key)
+		if ok {
+			s, ok := i.(*Subscription)
+			if ok && (s.p == nil || s.p(evt)) {
+				s.fn(evt)
+			}
 		}
 	}
 }

--- a/eventstream/eventstream_test.go
+++ b/eventstream/eventstream_test.go
@@ -3,32 +3,37 @@ package eventstream
 import (
 	"testing"
 
+	cmap "github.com/orcaman/concurrent-map"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEventStream_Subscribe(t *testing.T) {
-	es := &EventStream{}
+	es := &EventStream{
+		subscriptions: cmap.New(),
+	}
 	s := es.Subscribe(func(interface{}) {})
 	assert.NotNil(t, s)
-	assert.Len(t, es.subscriptions, 1)
+	assert.Equal(t, es.subscriptions.Count(), 1)
 }
 
 func TestEventStream_Unsubscribe(t *testing.T) {
-	es := &EventStream{}
+	es := &EventStream{
+		subscriptions: cmap.New(),
+	}
 	var c1, c2 int
 
 	s1 := es.Subscribe(func(interface{}) { c1++ })
 	s2 := es.Subscribe(func(interface{}) { c2++ })
-	assert.Len(t, es.subscriptions, 2)
+	assert.Equal(t, es.subscriptions.Count(), 2)
 
 	es.Unsubscribe(s2)
-	assert.Len(t, es.subscriptions, 1)
+	assert.Equal(t, es.subscriptions.Count(), 1)
 
 	es.Publish(1)
 	assert.Equal(t, 1, c1)
 
 	es.Unsubscribe(s1)
-	assert.Empty(t, es.subscriptions)
+	assert.Equal(t, es.subscriptions.Count(), 0)
 
 	es.Publish(1)
 	assert.Equal(t, 1, c1)
@@ -36,7 +41,9 @@ func TestEventStream_Unsubscribe(t *testing.T) {
 }
 
 func TestEventStream_Publish(t *testing.T) {
-	es := &EventStream{}
+	es := &EventStream{
+		subscriptions: cmap.New(),
+	}
 
 	var v int
 	es.Subscribe(func(m interface{}) { v = m.(int) })
@@ -50,7 +57,9 @@ func TestEventStream_Publish(t *testing.T) {
 
 func TestEventStream_Subscribe_WithPredicate_IsCalled(t *testing.T) {
 	called := false
-	es := &EventStream{}
+	es := &EventStream{
+		subscriptions: cmap.New(),
+	}
 	es.Subscribe(func(interface{}) { called = true }).
 		WithPredicate(func(m interface{}) bool { return true })
 	es.Publish("")
@@ -60,7 +69,9 @@ func TestEventStream_Subscribe_WithPredicate_IsCalled(t *testing.T) {
 
 func TestEventStream_Subscribe_WithPredicate_IsNotCalled(t *testing.T) {
 	called := false
-	es := &EventStream{}
+	es := &EventStream{
+		subscriptions: cmap.New(),
+	}
 	es.Subscribe(func(interface{}) { called = true }).
 		WithPredicate(func(m interface{}) bool { return false })
 	es.Publish("")

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20191027212112-611e8accdfc9 // indirect
 	github.com/golang/lint v0.0.0-20181217174547-8f45f776aaf1 // indirect
 	github.com/golang/protobuf v1.3.2
+	github.com/google/uuid v1.1.1
 	github.com/googleapis/gnostic v0.3.1 // indirect
 	github.com/gophercloud/gophercloud v0.6.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/go.sum
+++ b/go.sum
@@ -774,6 +774,7 @@ github.com/google/uuid v0.0.0-20170306145142-6a5e28554805/go.mod h1:TIyPZe4Mgqvf
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.0 h1:Jf4mxPC/ziBnoPIdpQdPJ9OeiomAUHLvxmPRSPH9m4s=
 github.com/google/uuid v1.1.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go v2.0.2+incompatible h1:silFMLAnr330+NRuag/VjIGF7TLp/LBrV2CJKFLWEww=


### PR DESCRIPTION
This removes the concurrency issue mentioned in this PR https://github.com/AsynkronIT/protoactor-go/pull/371