### PR TITLE
Add UnboundedPriority mailbox type

### DIFF
--- a/mailbox/priority_queue.go
+++ b/mailbox/priority_queue.go
@@ -1,0 +1,68 @@
+package mailbox
+
+// A priority queue is a sort of meta-queue that uses a queue per priority level.
+// The underlying queues can be anything that implements the queue interface.
+//
+// Messages that implement the PriorityMessage interface (i.e. have a GetPriority
+// method) will be consumed in priority order first, queue order second. So if a
+// higher priority message arrives, it will jump to the front of the queue from
+// the consumer's perspective.
+//
+// There are 8 priority levels (0-7) because having too many levels impacts
+// performance. And 8 priority levels ought to be enough for anybody. ;)
+// This means your GetPriority method should return int8s between 0 and 7. If any
+// return values are higher or lower, they will be reset to 7 or 0, respectively.
+//
+// The default priority level is 4 for messages that don't implement PriorityMessage.
+// If you want your message processed sooner than un-prioritized messages, have its
+// GetPriority method return a larger int8 value.
+// Likewise if you'd like to de-prioritize your message, have its GetPriority method
+// return an int8 less than 4.
+
+const priorityLevels = 8
+const DefaultPriority = int8(priorityLevels / 2)
+
+type PriorityMessage interface {
+	GetPriority() int8
+}
+
+type priorityQueue struct {
+	priorityQueues []queue
+}
+
+func NewPriorityQueue(queueProducer func() queue) *priorityQueue {
+	q := &priorityQueue{
+		priorityQueues: make([]queue, priorityLevels),
+	}
+
+	for p := 0; p < priorityLevels; p++ {
+		q.priorityQueues[p] = queueProducer()
+	}
+
+	return q
+}
+
+func (q *priorityQueue) Push(item interface{}) {
+	itemPriority := DefaultPriority
+
+	if priorityItem, ok := item.(PriorityMessage); ok {
+		itemPriority = priorityItem.GetPriority()
+		if itemPriority < 0 {
+			itemPriority = 0
+		}
+		if itemPriority > priorityLevels - 1 {
+			itemPriority = priorityLevels - 1
+		}
+	}
+
+	q.priorityQueues[itemPriority].Push(item)
+}
+
+func (q *priorityQueue) Pop() interface{} {
+	for p := priorityLevels - 1; p >= 0; p-- {
+		if item := q.priorityQueues[p].Pop(); item != nil {
+			return item
+		}
+	}
+	return nil
+}

--- a/mailbox/priority_queue_test.go
+++ b/mailbox/priority_queue_test.go
@@ -1,0 +1,193 @@
+package mailbox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/AsynkronIT/protoactor-go/internal/queue/goring"
+	"github.com/AsynkronIT/protoactor-go/internal/queue/mpsc"
+)
+
+type Message interface {
+	GetMessage() string
+}
+
+type TestPriorityMessage struct {
+	message  string
+	priority int8
+}
+
+type TestMessage struct {
+	message string
+}
+
+func (tpm *TestPriorityMessage) GetPriority() int8 {
+	return tpm.priority
+}
+
+func (tpm *TestPriorityMessage) GetMessage() string {
+	return tpm.message
+}
+
+func (tm *TestMessage) GetMessage() string {
+	return tm.message
+}
+
+func NewTestGoringPriorityQueue() *priorityQueue {
+	return NewPriorityQueue(func() queue {
+		return &unboundedMailboxQueue{
+			userMailbox: goring.New(1),
+		}
+	})
+}
+
+func NewTestMpscPriorityQueue() *priorityQueue {
+	return NewPriorityQueue(func() queue {
+		return mpsc.New()
+	})
+}
+
+func TestPushPopGoring(t *testing.T) {
+	q := NewTestGoringPriorityQueue()
+	q.Push("hello")
+	res := q.Pop()
+	assert.Equal(t, "hello", res)
+}
+
+func TestPushPopGoringPriority(t *testing.T) {
+	q := NewTestGoringPriorityQueue()
+
+	// pushes
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestPriorityMessage{
+			message:  "7 hello",
+			priority: 7,
+		})
+	}
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestPriorityMessage{
+			message:  "5 hello",
+			priority: 5,
+		})
+	}
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestPriorityMessage{
+			message:  "0 hello",
+			priority: 0,
+		})
+	}
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestPriorityMessage{
+			message:  "6 hello",
+			priority: 6,
+		})
+	}
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestMessage{message: "hello"})
+	}
+
+	// pops in priority order
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "7 hello", res.(Message).GetMessage())
+	}
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "6 hello", res.(Message).GetMessage())
+	}
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "5 hello", res.(Message).GetMessage())
+	}
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "hello", res.(Message).GetMessage())
+	}
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "0 hello", res.(Message).GetMessage())
+	}
+}
+
+func TestPushPopMpsc(t *testing.T) {
+	q := NewTestMpscPriorityQueue()
+	q.Push("hello")
+	res := q.Pop()
+	assert.Equal(t, "hello", res)
+}
+
+func TestPushPopMpscPriority(t *testing.T) {
+	q := NewTestMpscPriorityQueue()
+
+	// pushes
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestPriorityMessage{
+			message:  "7 hello",
+			priority: 7,
+		})
+	}
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestPriorityMessage{
+			message:  "5 hello",
+			priority: 5,
+		})
+	}
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestPriorityMessage{
+			message:  "0 hello",
+			priority: 0,
+		})
+	}
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestPriorityMessage{
+			message:  "6 hello",
+			priority: 6,
+		})
+	}
+
+	for i := 0; i < 2; i++ {
+		q.Push(&TestMessage{message: "hello"})
+	}
+
+	// pops in priority order
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "7 hello", res.(Message).GetMessage())
+	}
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "6 hello", res.(Message).GetMessage())
+	}
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "5 hello", res.(Message).GetMessage())
+	}
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "hello", res.(Message).GetMessage())
+	}
+
+	for i := 0; i < 2; i++ {
+		res := q.Pop()
+		assert.Equal(t, "0 hello", res.(Message).GetMessage())
+	}
+}

--- a/mailbox/unbounded_priority.go
+++ b/mailbox/unbounded_priority.go
@@ -1,0 +1,40 @@
+package mailbox
+
+import (
+	"github.com/AsynkronIT/protoactor-go/internal/queue/goring"
+	"github.com/AsynkronIT/protoactor-go/internal/queue/mpsc"
+)
+
+func NewPriorityGoringQueue() *priorityQueue {
+	return NewPriorityQueue(func() queue {
+		return &unboundedMailboxQueue{
+			userMailbox: goring.New(10),
+		}
+	})
+}
+
+func UnboundedPriority(mailboxStats ...Statistics) Producer {
+	return func() Mailbox {
+		return &defaultMailbox{
+			systemMailbox: mpsc.New(),
+			userMailbox:   NewPriorityGoringQueue(),
+			mailboxStats:  mailboxStats,
+		}
+	}
+}
+
+func NewPriorityMpscQueue() *priorityQueue {
+	return NewPriorityQueue(func() queue {
+		return mpsc.New()
+	})
+}
+
+func UnboundedPriorityMpsc(mailboxStats ...Statistics) Producer {
+	return func() Mailbox {
+		return &defaultMailbox{
+			systemMailbox: mpsc.New(),
+			userMailbox:   NewPriorityMpscQueue(),
+			mailboxStats:  mailboxStats,
+		}
+	}
+}


### PR DESCRIPTION
Prioritizes messages into 0-7 (0 = lowest, 7 = highest) based on return value of their GetPriority method.

Rebased & conflict-free version of #380.