### PR TITLE
Fix log time

### DIFF
--- a/log/string_encoder.go
+++ b/log/string_encoder.go
@@ -35,7 +35,7 @@ func (l *ioLogger) listenEvent() {
 }
 
 // Cheap integer to fixed-width decimal ASCII.  Give a negative width to avoid zero-padding.
-func itoa(buf bytes.Buffer, i int, wid int) {
+func itoa(buf *bytes.Buffer, i int, wid int) {
 	// Assemble decimal in reverse order.
 	var b [20]byte
 	bp := len(b) - 1
@@ -51,7 +51,7 @@ func itoa(buf bytes.Buffer, i int, wid int) {
 	buf.Write(b[bp:])
 }
 
-func (l *ioLogger) formatHeader(buf bytes.Buffer, prefix string, t time.Time) {
+func (l *ioLogger) formatHeader(buf *bytes.Buffer, prefix string, t time.Time) {
 	t = t.UTC()
 	// Y/M/D
 	year, month, day := t.Date()
@@ -83,7 +83,7 @@ func (l *ioLogger) formatHeader(buf bytes.Buffer, prefix string, t time.Time) {
 
 func (l *ioLogger) writeEvent(e Event) {
 	var buf = bytes.Buffer{}
-	l.formatHeader(buf, e.Prefix, e.Time)
+	l.formatHeader(&buf, e.Prefix, e.Time)
 	if len(e.Message) > 0 {
 		buf.WriteString(e.Message)
 		buf.WriteByte(' ')


### PR DESCRIPTION
A little fix. After this `pr`, the log would works with time and prefix.

```bash
2020/09/27 11:16:25 [REMOTE] Started EndpointManager 
2020/09/27 11:16:25 [REMOTE] Starting Proto.Actor server address="127.0.0.1:8080" 
2020/09/27 11:16:25 [REMOTE] Started Activator 
2020/09/27 11:16:25 [CLUSTER] Starting Proto.Actor cluster address="127.0.0.1:8080" 
2020/09/27 11:16:25 [CLUSTER] Started kind="Hello" id="partition-Hello"
```

But there is a question, why not print local time? 
https://github.com/AsynkronIT/protoactor-go/blob/b225d28383f2318e0513dfabd22a3037f9043ffd/log/string_encoder.go#L55

/cc @PotterDai  @rogeralsing 