### PR TITLE
Fix log

### DIFF
--- a/log/string_encoder.go
+++ b/log/string_encoder.go
@@ -52,7 +52,6 @@ func itoa(buf *bytes.Buffer, i int, wid int) {
 }
 
 func (l *ioLogger) formatHeader(buf *bytes.Buffer, prefix string, t time.Time) {
-	t = t.UTC()
 	// Y/M/D
 	year, month, day := t.Date()
 	itoa(buf, year, 4)

--- a/remote/server.go
+++ b/remote/server.go
@@ -1,9 +1,9 @@
 package remote
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"time"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
@@ -34,8 +34,7 @@ func (r *Remote) Start() {
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 	lis, err := net.Listen("tcp", r.config.Address())
 	if err != nil {
-		plog.Error("failed to listen", log.Error(err))
-		os.Exit(1)
+		panic(fmt.Errorf("failed to listen: %v", err))
 	}
 
 	var address string


### PR DESCRIPTION
[This problem] solved by use panic.
```
panic: failed to listen: listen tcp 127.0.0.1:8080: bind: address already in use                                                                                                     

goroutine 1 [running]:                       
github.com/AsynkronIT/protoactor-go/remote.(*Remote).Start(0xc000172e10)                                                                                                             
        /home/cupen/workbench/repos/protoactor-go/remote/server.go:37 +0x6a9                                                                                                         
main.main()                                  
        /home/cupen/workbench/repos/protoactor-go/_examples/remote-benchmark/node1/main.go:85 +0x257                                                                                 
exit status 2 
```
[This problem]: https://github.com/AsynkronIT/protoactor-go/issues/396#issuecomment-724134290 