### PR TITLE
Refactor remote.endpointManager

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -28,6 +28,7 @@ var completer = readline.NewPrefixCompleter(
 	readline.PcItem("watch"),
 	readline.PcItem("exit"),
 )
+var remoting *remote.Remote
 
 func filterInput(r rune) (rune, bool) {
 	switch r {
@@ -51,7 +52,7 @@ func main() {
 	actorSystem := actor.NewActorSystem()
 
 	rc := remote.Configure("127.0.0.1", 0)
-	remoting := remote.NewRemote(actorSystem, rc)
+	remoting = remote.NewRemote(actorSystem, rc)
 
 	remote.DefaultSerializerID = 1
 	remoting.Start()
@@ -167,7 +168,7 @@ func tell(line string) {
 				TypeName: typeNameStr,
 			}
 			pid := actor.NewPID(address, id)
-			remote.SendMessage(pid, nil, m, nil, 1)
+			remoting.SendMessage(pid, nil, m, nil, 1)
 		} else {
 			fmt.Printf("Invalid JSON payload: %v\n", err)
 		}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -124,10 +124,10 @@ func (c *Cluster) Get(name string, kind string) (*actor.PID, remote.ResponseStat
 	remotePartition := c.partitionValue.partitionForKind(address, kind)
 	r, err := c.ActorSystem.Root.RequestFuture(remotePartition, req, c.Config.TimeoutTime).Result()
 	if err == actor.ErrTimeout {
-		plog.Error("PidCache Pid request timeout")
+		plog.Error("PidCache Pid request timeout", log.String("remote", remotePartition.String()))
 		return nil, remote.ResponseStatusCodeTIMEOUT
 	} else if err != nil {
-		plog.Error("PidCache Pid request error", log.Error(err))
+		plog.Error("PidCache Pid request error", log.Error(err), log.String("remote", remotePartition.String()))
 		return nil, remote.ResponseStatusCodeERROR
 	}
 

--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -9,16 +9,6 @@ import (
 	"github.com/AsynkronIT/protoactor-go/log"
 )
 
-func (r *Remote) spawnActivatorActor() {
-	p := newActivatorActor(r)
-	props := actor.PropsFromProducer(p).WithGuardian(actor.RestartingSupervisorStrategy())
-	r.activatorPid, _ = r.actorSystem.Root.SpawnNamed(props, "activator")
-}
-
-func (r *Remote) stopActivatorActor() {
-	_ = r.actorSystem.Root.StopFuture(r.activatorPid).Wait()
-}
-
 // Register a known actor props by name
 func (r *Remote) Register(kind string, props *actor.Props) {
 	r.nameLookup[kind] = *props
@@ -98,6 +88,8 @@ func (a *activator) Receive(context actor.Context) {
 	switch msg := context.Message().(type) {
 	case *actor.Started:
 		plog.Debug("Started Activator")
+	case *Ping:
+		context.Respond(&Pong{})
 	case *ActorPidRequest:
 		props, exist := a.remote.nameLookup[msg.Kind]
 

--- a/remote/endpoint_reader.go
+++ b/remote/endpoint_reader.go
@@ -69,7 +69,7 @@ func (s *endpointReader) Receive(stream Remoting_ReceiveServer) error {
 					Watchee: msg.Who,
 					Watcher: pid,
 				}
-				endpointManager.remoteTerminate(rt)
+				s.remote.edpManager.remoteTerminate(rt)
 			case actor.SystemMessage:
 				ref, _ := s.remote.actorSystem.ProcessRegistry.GetLocal(pid.Id)
 				ref.SendSystemMessage(pid, msg)
@@ -91,4 +91,7 @@ func (s *endpointReader) Receive(stream Remoting_ReceiveServer) error {
 
 func (s *endpointReader) suspend(toSuspend bool) {
 	s.suspended = toSuspend
+	if toSuspend {
+		plog.Debug("Suspended EndpointReader")
+	}
 }

--- a/remote/endpoint_watcher.go
+++ b/remote/endpoint_watcher.go
@@ -58,7 +58,8 @@ func (state *endpointWatcher) connected(ctx actor.Context) {
 	case *EndpointConnectedEvent:
 		// Already connected, pass
 	case *EndpointTerminatedEvent:
-		plog.Info("EndpointWatcher handling terminated", log.String("address", state.address))
+		plog.Info("EndpointWatcher handling terminated",
+			log.String("address", state.address), log.Int("watched", len(state.watched)))
 
 		for id, pidSet := range state.watched {
 			// try to find the watcher ID in the local actor registry
@@ -97,7 +98,7 @@ func (state *endpointWatcher) connected(ctx actor.Context) {
 		}
 
 		// pass it off to the remote PID
-		SendMessage(msg.Watchee, nil, w, nil, -1)
+		state.remote.SendMessage(msg.Watchee, nil, w, nil, -1)
 
 	case *remoteUnwatch:
 		// delete the watch entries
@@ -114,7 +115,7 @@ func (state *endpointWatcher) connected(ctx actor.Context) {
 		}
 
 		// pass it off to the remote PID
-		SendMessage(msg.Watchee, nil, uw, nil, -1)
+		state.remote.SendMessage(msg.Watchee, nil, uw, nil, -1)
 	case actor.SystemMessage, actor.AutoReceiveMessage:
 		// ignore
 	default:

--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -40,16 +40,17 @@ func (state *endpointWriter) initialize() {
 }
 
 func (state *endpointWriter) initializeInternal() error {
-	plog.Info("Started EndpointWriter", log.String("address", state.address))
-	plog.Info("EndpointWriter connecting", log.String("address", state.address))
+	plog.Info("Started EndpointWriter. connecting", log.String("address", state.address))
 	conn, err := grpc.Dial(state.address, state.config.DialOptions...)
 	if err != nil {
+		plog.Info("EndpointWriter connect failed", log.String("address", state.address), log.Error(err))
 		return err
 	}
 	state.conn = conn
 	c := NewRemotingClient(conn)
 	resp, err := c.Connect(context.Background(), &ConnectRequest{})
 	if err != nil {
+		plog.Info("EndpointWriter connect failed", log.String("address", state.address), log.Error(err))
 		return err
 	}
 	state.defaultSerializerId = resp.DefaultSerializerId
@@ -57,6 +58,7 @@ func (state *endpointWriter) initializeInternal() error {
 	//	log.Printf("Getting stream from address %v", state.address)
 	stream, err := c.Receive(context.Background(), state.config.CallOptions...)
 	if err != nil {
+		plog.Info("EndpointWriter connect failed", log.String("address", state.address), log.Error(err))
 		return err
 	}
 	go func() {

--- a/remote/messages.go
+++ b/remote/messages.go
@@ -47,3 +47,11 @@ var (
 	ActorPidRespTimeout     interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeTIMEOUT.ToInt32()}
 	ActorPidRespUnavailable interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeUNAVAILABLE.ToInt32()}
 )
+
+type (
+	// Ping is message sent by the actor system to probe an actor is started.
+	Ping struct{}
+
+	// Pong is response for ping.
+	Pong struct{}
+)

--- a/remote/remote_handler.go
+++ b/remote/remote_handler.go
@@ -2,7 +2,12 @@ package remote
 
 import "github.com/AsynkronIT/protoactor-go/actor"
 
-func remoteHandler(pid *actor.PID) (actor.Process, bool) {
-	ref := newProcess(pid)
+// func remoteHandler(pid *actor.PID) (actor.Process, bool) {
+// 	ref := newProcess(pid, nil)
+// 	return ref, true
+// }
+
+func (r *Remote) remoteHandler(pid *actor.PID) (actor.Process, bool) {
+	ref := newProcess(pid, r)
 	return ref, true
 }


### PR DESCRIPTION
The EndpointManager is a global variable, so it can't work with several nodes in one `os/process`.
It's fixed now.