### PR TITLE
Gracefull remote shutdown

### DIFF
--- a/_examples/remote-benchmark/node2/main.go
+++ b/_examples/remote-benchmark/node2/main.go
@@ -12,31 +12,38 @@ import (
 	"github.com/AsynkronIT/protoactor-go/remote"
 )
 
+type echoActor struct {
+	sender *actor.PID
+}
+
+func (state *echoActor) Receive(context actor.Context) {
+	switch msg := context.Message().(type) {
+	case *messages.StartRemote:
+		log.Printf("Starting for %s", msg.Sender)
+		state.sender = msg.Sender
+		context.Respond(&messages.Start{})
+	case *messages.Ping:
+		context.Send(state.sender, &messages.Pong{})
+	}
+}
+
 func main() {
 	runtime.GOMAXPROCS(runtime.NumCPU() * 1)
 	runtime.GC()
 
+	props := actor.
+		PropsFromProducer(func() actor.Actor { return &echoActor{} }).
+		WithMailbox(mailbox.Bounded(1000000))
+
 	system := actor.NewActorSystem()
-	r := remote.NewRemote(system, remote.Configure("127.0.0.1", 8080))
+	r := remote.NewRemote(system, remote.Configure("127.0.0.1", 12000))
+	r.Register("echo", props)
 	r.Start()
 
-	var sender *actor.PID
 	rootContext := system.Root
-	props := actor.
-		PropsFromFunc(
-			func(context actor.Context) {
-				switch msg := context.Message().(type) {
-				case *messages.StartRemote:
-					log.Println("Starting")
-					sender = msg.Sender
-					context.Respond(&messages.Start{})
-				case *messages.Ping:
-					context.Send(sender, &messages.Pong{})
-				}
-			}).
-		WithMailbox(mailbox.Bounded(1000000))
 
 	rootContext.SpawnNamed(props, "remote")
 
 	console.ReadLine()
+	r.Shutdown(true)
 }

--- a/remote/endpoint_reader.go
+++ b/remote/endpoint_reader.go
@@ -36,8 +36,8 @@ func (s *endpointReader) Receive(stream Remoting_ReceiveServer) error {
 		close(disconnectChan)
 	}()
 	go func() {
-		// endpointManager send true
-		// endpointReader send false
+		// endpointManager sends true
+		// endpointReader sends false
 		if <-disconnectChan {
 			plog.Debug("EndpointReader is telling to remote that it's leaving")
 			err := stream.SendMsg(&Unit{})

--- a/remote/endpoint_reader.go
+++ b/remote/endpoint_reader.go
@@ -1,7 +1,7 @@
 package remote
 
 import (
-	"time"
+	io "io"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/log"
@@ -30,17 +30,39 @@ func (s *endpointReader) Connect(ctx context.Context, req *ConnectRequest) (*Con
 }
 
 func (s *endpointReader) Receive(stream Remoting_ReceiveServer) error {
+	disconnectChan := make(chan bool, 1)
+	s.remote.edpManager.endpointReaderConnections.Store(stream, disconnectChan)
+	defer func() {
+		close(disconnectChan)
+	}()
+	go func() {
+		// endpointManager send true
+		// endpointReader send false
+		if <-disconnectChan {
+			plog.Debug("EndpointReader is telling to remote that it's leaving")
+			err := stream.SendMsg(&Unit{})
+			if err != nil {
+				plog.Error("EndpointReader failed to send disconnection message", log.Error(err))
+			}
+		} else {
+			s.remote.edpManager.endpointReaderConnections.Delete(stream)
+			plog.Debug("EndpointReader removed active endpoint from endpointManager")
+		}
+	}()
+
 	targets := make([]*actor.PID, 100)
 	for {
-		if s.suspended {
-			time.Sleep(time.Millisecond * 500)
-			continue
-		}
-
 		batch, err := stream.Recv()
-		if err != nil {
-			plog.Debug("EndpointReader failed to read", log.Error(err))
+		if err == io.EOF {
+			plog.Debug("EndpointReader stream closed")
+			disconnectChan <- false
+			return nil
+		} else if err != nil {
+			plog.Info("EndpointReader failed to read", log.Error(err))
 			return err
+		} else if s.suspended {
+			// We read all messages ignoring them to gracefully end the request
+			continue
 		}
 
 		// only grow pid lookup if needed

--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -181,22 +181,12 @@ func (state *endpointWriter) Receive(ctx actor.Context) {
 			if err != nil {
 				plog.Error("EndpointWriter error when closing the stream", log.Error(err))
 			}
-		} else {
-			err := state.conn.Close()
-			if err != nil {
-				plog.Error("EndpointWriter error when closing the channel", log.Error(err))
-			}
 		}
 	case *actor.Restarting:
 		if state.stream != nil {
 			err := state.stream.CloseSend()
 			if err != nil {
 				plog.Error("EndpointWriter error when closing the stream", log.Error(err))
-			}
-		} else {
-			err := state.conn.Close()
-			if err != nil {
-				plog.Error("EndpointWriter error when closing the channel", log.Error(err))
 			}
 		}
 	case *EndpointTerminatedEvent:

--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	io "io"
 	"time"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
@@ -62,15 +63,28 @@ func (state *endpointWriter) initializeInternal() error {
 		return err
 	}
 	go func() {
-		_, err := stream.Recv()
-		if err != nil {
-			plog.Info("EndpointWriter lost connection to address", log.String("address", state.address), log.Error(err))
+		for {
+			_, err := stream.Recv()
+			if err == io.EOF {
+				plog.Debug("EndpointWriter stream completed", log.String("address", state.address))
+				break
+			} else if err != nil {
+				plog.Error("EndpointWriter lost connection", log.String("address", state.address), log.Error(err))
 
-			// notify that the endpoint terminated
-			terminated := &EndpointTerminatedEvent{
-				Address: state.address,
+				// notify that the endpoint terminated
+				terminated := &EndpointTerminatedEvent{
+					Address: state.address,
+				}
+				state.remote.actorSystem.EventStream.Publish(terminated)
+				break
+			} else {
+				plog.Info("EndpointWriter remote disconnected", log.String("address", state.address))
+				// notify that the endpoint terminated
+				terminated := &EndpointTerminatedEvent{
+					Address: state.address,
+				}
+				state.remote.actorSystem.EventStream.Publish(terminated)
 			}
-			state.remote.actorSystem.EventStream.Publish(terminated)
 		}
 	}()
 
@@ -162,9 +176,29 @@ func (state *endpointWriter) Receive(ctx actor.Context) {
 	case *actor.Started:
 		state.initialize()
 	case *actor.Stopped:
-		_ = state.conn.Close()
+		if state.stream != nil {
+			err := state.stream.CloseSend()
+			if err != nil {
+				plog.Error("EndpointWriter error when closing the stream", log.Error(err))
+			}
+		} else {
+			err := state.conn.Close()
+			if err != nil {
+				plog.Error("EndpointWriter error when closing the channel", log.Error(err))
+			}
+		}
 	case *actor.Restarting:
-		_ = state.conn.Close()
+		if state.stream != nil {
+			err := state.stream.CloseSend()
+			if err != nil {
+				plog.Error("EndpointWriter error when closing the stream", log.Error(err))
+			}
+		} else {
+			err := state.conn.Close()
+			if err != nil {
+				plog.Error("EndpointWriter error when closing the channel", log.Error(err))
+			}
+		}
 	case *EndpointTerminatedEvent:
 		ctx.Stop(ctx.Self())
 	case []interface{}:


### PR DESCRIPTION
Hello,
As this is my first PR in go language, it's maybe not perfect :-)  but here you will find some code to gracefully handle remote shutdown. I used to same approach in the dotnet project.

When a remote instance is about to stop, the endpointReader has to send a unit message to all of the endpointWriters to stop the connections.
In grpc, the caller has to terminate the connection. And to gracefully shutdown, the grpc server has to finish all the incoming queries.

For example :
- On Node A endpointManger is stopping, it tells to all active receive methods on endpointReaders to send a Unit message.
- On Node X endpointWriter receives the unit message and publishes an EndpointTerminatedEvent event
- On Node X endpointManager handles the EndpointTerminatedEvent event and stops the endpoint actors for this address. When the endpointWriter stops it closes the connection to Node A.