### PR TITLE
Fix missing publish SupervisorEvent from SupervisorStrategy handler

### DIFF
--- a/actor/strategy_exponential_backoff.go
+++ b/actor/strategy_exponential_backoff.go
@@ -28,6 +28,7 @@ func (strategy *exponentialBackoffStrategy) HandleFailure(actorSystem *ActorSyst
 	noise := rand.Intn(500)
 	dur := time.Duration(backoff + noise)
 	time.AfterFunc(dur, func() {
+		logFailure(actorSystem, child, reason, RestartDirective)
 		supervisor.RestartChildren(child)
 	})
 }

--- a/actor/strategy_restarting.go
+++ b/actor/strategy_restarting.go
@@ -8,5 +8,6 @@ type restartingStrategy struct{}
 
 func (strategy *restartingStrategy) HandleFailure(actorSystem *ActorSystem, supervisor Supervisor, child *PID, rs *RestartStatistics, reason interface{}, message interface{}) {
 	// always restart
+	logFailure(actorSystem, child, reason, RestartDirective)
 	supervisor.RestartChildren(child)
 }

--- a/actor/supervision_event_test.go
+++ b/actor/supervision_event_test.go
@@ -1,0 +1,60 @@
+package actor
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+type panicActor struct{}
+
+func (a *panicActor) Receive(ctx Context) {
+	switch ctx.Message().(type) {
+	case string:
+		panic("Boom!")
+	}
+}
+
+func TestSupervisorEventHandleFromEventstream(t *testing.T) {
+	supervisors := []struct {
+		name     string
+		strategy SupervisorStrategy
+	}{
+		{
+			name:     "all_for_one",
+			strategy: NewAllForOneStrategy(10, 10*time.Second, DefaultDecider),
+		},
+		{
+			name:     "exponential_backoff",
+			strategy: NewExponentialBackoffStrategy(10*time.Millisecond, 10*time.Millisecond),
+		},
+		{
+			name:     "one_for_one",
+			strategy: NewOneForOneStrategy(10, 10*time.Second, DefaultDecider),
+		},
+		{
+			name:     "restarting",
+			strategy: NewRestartingStrategy(),
+		},
+	}
+
+	for _, v := range supervisors {
+		t.Run(v.name, func(t *testing.T) {
+			wg := sync.WaitGroup{}
+			sid := system.EventStream.Subscribe(func(evt interface{}) {
+				if _, ok := evt.(*SupervisorEvent); ok {
+					wg.Done()
+				}
+			})
+			defer system.EventStream.Unsubscribe(sid)
+
+			props := PropsFromProducer(func() Actor { return &panicActor{} }).WithSupervisor(v.strategy)
+			pid := rootContext.Spawn(props)
+
+			wg.Add(1)
+			rootContext.Send(pid, "Fail!")
+
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
Some SupervisorStrategy does not publish events in the HandleFailure method.
- exponential backoff strategy
- restarting strategy

I think all supervisors should publish the same events in the same action.