### PR TITLE
Update cluster broadcast example

### DIFF
--- a/_examples/cluster-broadcast/go.mod
+++ b/_examples/cluster-broadcast/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/AsynkronIT/goconsole v0.0.0-20160504192649-bfa12eebf716
 	github.com/AsynkronIT/protoactor-go v0.0.0-00010101000000-000000000000
 	github.com/gogo/protobuf v1.3.1
+	google.golang.org/grpc v1.34.0
 )

--- a/_examples/cluster-broadcast/node1/main.go
+++ b/_examples/cluster-broadcast/node1/main.go
@@ -46,26 +46,25 @@ func startNode(port int64) *cluster.Cluster {
 	timeout := 10 * time.Minute
 
 	system := actor.NewActorSystem()
-	config := remote.Configure("localhost", 0)
-	remote := remote.NewRemote(system, config)
+	shared.SetSystem(system)
 
-	provider := automanaged.NewWithConfig(2*time.Second, 6331, "localhost:6330", "localhost:6331")
-	clusterConfig := cluster.Configure("my-cluster", provider, config)
-	cluster := cluster.New(system, clusterConfig)
-
-	// this node knows about Hello kind
-	remote.Register("Calculator", actor.PropsFromProducer(func() actor.Actor {
+	calcKind := cluster.NewKind("Calculator", actor.PropsFromProducer(func() actor.Actor {
 		return &shared.CalculatorActor{
 			Timeout: &timeout,
 		}
 	}))
-
-	// this node knows about Hello kind
-	remote.Register("Tracker", actor.PropsFromProducer(func() actor.Actor {
+	trackerKind := cluster.NewKind("Tracker", actor.PropsFromProducer(func() actor.Actor {
 		return &shared.TrackerActor{
 			Timeout: &timeout,
 		}
 	}))
+
+	provider := automanaged.NewWithConfig(2*time.Second, 6331, "localhost:6330", "localhost:6331")
+	config := remote.Configure("localhost", 0)
+
+	clusterConfig := cluster.Configure("my-cluster", provider, config, calcKind, trackerKind)
+	cluster := cluster.New(system, clusterConfig)
+	shared.SetCluster(cluster)
 
 	shared.CalculatorFactory(func() shared.Calculator {
 		return &shared.CalcGrain{}

--- a/_examples/cluster-broadcast/shared/trackerGrain.go
+++ b/_examples/cluster-broadcast/shared/trackerGrain.go
@@ -2,7 +2,7 @@ package shared
 
 import (
 	"fmt"
-
+	"strings"
 	"github.com/AsynkronIT/protoactor-go/cluster"
 )
 
@@ -20,7 +20,9 @@ func (t *TrackGrain) Terminate() {
 }
 
 func (t *TrackGrain) RegisterGrain(n *RegisterMessage, ctx cluster.GrainContext) (*Noop, error) {
-	t.grainsMap[n.GrainId] = true
+	parts := strings.Split(n.GrainId, "/")
+	grainID := parts[len(parts) - 1]
+	t.grainsMap[grainID] = true
 	return &Noop{}, nil
 }
 

--- a/_examples/cluster-metrics/go.mod
+++ b/_examples/cluster-metrics/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/AsynkronIT/goconsole v0.0.0-20160504192649-bfa12eebf716
 	github.com/AsynkronIT/protoactor-go v0.0.0-00010101000000-000000000000
 	github.com/gogo/protobuf v1.3.1
-	google.golang.org/grpc v1.25.1
+	google.golang.org/grpc v1.34.0
 )

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/labstack/echo v3.3.10+incompatible
 	github.com/labstack/gommon v0.3.0 // indirect
-	github.com/miekg/dns v1.1.22 // indirect
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/orcaman/concurrent-map v0.0.0-20190107190726-7ed82d9cb717
 	github.com/serialx/hashring v0.0.0-20180504054112-49a4782e9908


### PR DESCRIPTION
This updates cluster broadcast example to use the new `cluster.Call`
api. Also it completes the migration from the consul provider to the
automanaged one.