### PR TITLE
fix: 64-bit alignment of 64-bit words accessed atomically

### DIFF
--- a/actor/process_registry.go
+++ b/actor/process_registry.go
@@ -7,8 +7,8 @@ import (
 )
 
 type ProcessRegistryValue struct {
-	ActorSystem    *ActorSystem
 	SequenceID     uint64
+	ActorSystem    *ActorSystem
 	Address        string
 	LocalPIDs      cmap.ConcurrentMap
 	RemoteHandlers []AddressResolver

--- a/cluster/etcd/etcd_provider.go
+++ b/cluster/etcd/etcd_provider.go
@@ -21,6 +21,7 @@ var (
 )
 
 type Provider struct {
+	leaseID       clientv3.LeaseID
 	cluster       *cluster.Cluster
 	baseKey       string
 	clusterName   string
@@ -30,7 +31,6 @@ type Provider struct {
 	members       map[string]*Node // all, contains self.
 	clusterError  error
 	client        *clientv3.Client
-	leaseID       clientv3.LeaseID
 	cancelWatch   func()
 	cancelWatchCh chan bool
 	keepAliveTTL  time.Duration


### PR DESCRIPTION
From `sync/atomic` [docs](https://golang.org/pkg/sync/atomic/#pkg-note-BUG):

> On ARM, 386, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically. The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

Without these changes, `Spawn` gave the following panic on ARM:

```
panic: unaligned 64-bit atomic operation
```

I stumbled upon this while using protoactor on a raspberry pi. These two are the only ones I could find, but I am not well versed in Go nor do I understand enough about protoactor to feel comfortable saying these are all the alignments needed.