### PR TITLE
Fixed remote advertised address examples and added some documentation

### DIFF
--- a/_examples/remote-activate/node1/main.go
+++ b/_examples/remote-activate/node1/main.go
@@ -15,6 +15,7 @@ import (
 func main() {
 	timeout := 5 * time.Second
 
+	// configure the system as a remote one
 	system := actor.NewActorSystem()
 	r := remote.NewRemote(system, remote.Configure("127.0.0.1", 8081))
 	r.Start()
@@ -33,6 +34,7 @@ func main() {
 			}
 		})
 
+	// spawn the actor as a named actor
 	pidResp, _ := rootContext.SpawnNamed(props, "hello")
 
 	res, _ := rootContext.RequestFuture(pidResp, &messages.HelloRequest{}, timeout).Result()

--- a/_examples/remote-advertised-address/node1/main.go
+++ b/_examples/remote-advertised-address/node1/main.go
@@ -15,11 +15,13 @@ var (
 )
 
 func main() {
-	cfg := remote.Configure("0.0.0.0", 8081)
-	cfg = cfg.WithAdvertisedHost("localhost:8081")
+	// configure the remote with an advertised host address
+	cfg := cfg.WithAdvertisedHost("localhost:8081")
 	r := remote.NewRemote(system, cfg)
 	r.Start()
 
+	// use the advertised address of the remote actor in combination
+	// with the remote services name
 	remotePid := actor.NewPID("127.0.0.1:8080", "remote")
 
 	props := actor.

--- a/_examples/remote-advertised-address/node2/main.go
+++ b/_examples/remote-advertised-address/node2/main.go
@@ -15,8 +15,9 @@ var (
 )
 
 func main() {
-	cfg := remote.Configure("0.0.0.0", 8080)
-	cfg = cfg.WithAdvertisedHost("localhost:8080")
+	// configure the remote with an advertised host address so that
+	// other services could send messages
+	cfg := cfg.WithAdvertisedHost("localhost:8080")
 	r := remote.NewRemote(system, cfg)
 	r.Start()
 


### PR DESCRIPTION
I was working with the remote actor system when a saw a small ambiguity with configuring an advertised address remote. I've also added some doc comments to the example.