### PR TITLE
Add docker-compose services for cluster testcases 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.o
 *.a
 *.so
+*.orig
 
 
 # Folders

--- a/_examples/cluster-restartgracefully/docker-compose.yml
+++ b/_examples/cluster-restartgracefully/docker-compose.yml
@@ -5,10 +5,3 @@ services:
     image: redis:5.0.7-alpine
     ports:
       - 127.0.0.1:6380:6379
-
-  consul:
-    image: consul:1.8.4
-    ports:
-      - 8500:8500
-      - 8600:8600/udp
-    command: agent -server -ui -node=server-1 -bootstrap-expect=1 -client=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,19 @@
 # @see https://docs.docker.com/compose/compose-file/
 version: '3.4'
 services:
- dev-etcd:
+ consul:
+    container_name: dev-consul
+    image: consul:1.10
+    restart: unless-stopped
+    ports:
+      - 8500:8500
+      - 8600:8600/udp
+    command: agent -server -ui -node=server-1 -bootstrap-expect=1 -client=0.0.0.0
+
+
+ etcd:
     container_name: dev-etcd
-    image: quay.io/coreos/etcd:latest
+    image: quay.io/coreos/etcd:v3.5.0
     restart: unless-stopped
     ports:
       - 2379:2379
@@ -20,3 +30,10 @@ services:
           --initial-cluster node1=http://127.0.0.1:2380
           --auto-compaction-mode=periodic 
           --auto-compaction-retention=30m
+
+ zookeeper:
+    container_name: dev-zookeeper
+    image: zookeeper:3.7
+    restart: unless-stopped
+    ports:
+      - 8000:2181


### PR DESCRIPTION
```bash
$ docker-compose up -d
Creating network "protoactor-go_default" with the default driver
Creating dev-consul    ... done
Creating dev-etcd      ... done
Creating dev-zookeeper ... done
```

```
$ go test ./... -count=1 -timeout 30s
?   	github.com/AsynkronIT/protoactor-go	[no test files]
ok  	github.com/AsynkronIT/protoactor-go/actor	1.211s
?   	github.com/AsynkronIT/protoactor-go/actor/middleware	[no test files]
ok  	github.com/AsynkronIT/protoactor-go/actor/middleware/opentracing	0.018s [no tests to run]
ok  	github.com/AsynkronIT/protoactor-go/actor/middleware/propagator	0.008s
?   	github.com/AsynkronIT/protoactor-go/actor/middleware/protozip	[no test files]
?   	github.com/AsynkronIT/protoactor-go/cli	[no test files]
ok  	github.com/AsynkronIT/protoactor-go/cluster	1.038s
ok  	github.com/AsynkronIT/protoactor-go/cluster/automanaged	0.035s [no tests to run]
?   	github.com/AsynkronIT/protoactor-go/cluster/chash	[no test files]
ok  	github.com/AsynkronIT/protoactor-go/cluster/consul	2.287s
ok  	github.com/AsynkronIT/protoactor-go/cluster/etcd	0.141s
ok  	github.com/AsynkronIT/protoactor-go/cluster/zk	0.033s
ok  	github.com/AsynkronIT/protoactor-go/eventstream	0.023s
?   	github.com/AsynkronIT/protoactor-go/extensions	[no test files]
?   	github.com/AsynkronIT/protoactor-go/internal/core	[no test files]
ok  	github.com/AsynkronIT/protoactor-go/internal/queue/goring	1.538s
ok  	github.com/AsynkronIT/protoactor-go/internal/queue/mpsc	1.341s
ok  	github.com/AsynkronIT/protoactor-go/log	0.010s
ok  	github.com/AsynkronIT/protoactor-go/mailbox	2.702s
ok  	github.com/AsynkronIT/protoactor-go/persistence	0.046s
?   	github.com/AsynkronIT/protoactor-go/persistence/protocb	[no test files]
ok  	github.com/AsynkronIT/protoactor-go/plugin	1.204s
?   	github.com/AsynkronIT/protoactor-go/protobuf/protoc-gen-gograin	[no test files]
?   	github.com/AsynkronIT/protoactor-go/protobuf/protoc-gen-gograinv2	[no test files]
ok  	github.com/AsynkronIT/protoactor-go/remote	0.011s
ok  	github.com/AsynkronIT/protoactor-go/router	2.116s
ok  	github.com/AsynkronIT/protoactor-go/scheduler	0.043s
ok  	github.com/AsynkronIT/protoactor-go/stream	0.002s
```