### PR TITLE
Expose user message queue count in mailbox

### DIFF
--- a/mailbox/mailbox.go
+++ b/mailbox/mailbox.go
@@ -28,6 +28,7 @@ type Mailbox interface {
 	PostSystemMessage(message interface{})
 	RegisterHandlers(invoker MessageInvoker, dispatcher Dispatcher)
 	Start()
+	UserMessageCount() int
 }
 
 // Producer is a function which creates a new mailbox
@@ -159,4 +160,8 @@ func (m *defaultMailbox) Start() {
 	for _, ms := range m.mailboxStats {
 		ms.MailboxStarted()
 	}
+}
+
+func (m *defaultMailbox) UserMessageCount() int {
+	return int(m.userMessages)
 }

--- a/mailbox/mailbox.go
+++ b/mailbox/mailbox.go
@@ -163,5 +163,5 @@ func (m *defaultMailbox) Start() {
 }
 
 func (m *defaultMailbox) UserMessageCount() int {
-	return int(m.userMessages)
+	return int(atomic.LoadInt32(&m.userMessages))
 }

--- a/mailbox/mailbox_test.go
+++ b/mailbox/mailbox_test.go
@@ -132,3 +132,24 @@ func TestBoundedDroppingMailbox(t *testing.T) {
 	m.Push("4")
 	assert.Equal(t, "2", m.Pop())
 }
+
+func TestMailboxUserMessageCount(t *testing.T) {
+	max := 10
+	c := 10
+	var wg sync.WaitGroup
+	wg.Add(1)
+	p := UnboundedLockfree()
+	mi := &invoker{
+		max: max,
+		wg:  &wg,
+	}
+	q := p()
+	q.RegisterHandlers(mi, NewDefaultDispatcher(300))
+
+	for j := 0; j < c; j++ {
+		q.PostUserMessage(fmt.Sprintf("%v", j))
+	}
+	assert.Equal(t, c, q.UserMessageCount())
+	wg.Wait()
+	time.Sleep(100 * time.Millisecond)
+}

--- a/remote/endpoint_writer_mailbox.go
+++ b/remote/endpoint_writer_mailbox.go
@@ -114,6 +114,10 @@ func (m *endpointWriterMailbox) run() {
 	}
 }
 
+func (m *endpointWriterMailbox) UserMessageCount() int {
+	return int(m.userMailbox.Length())
+}
+
 func endpointWriterMailboxProducer(batchSize, initialSize int) mailbox.Producer {
 	return func() mailbox.Mailbox {
 		userMailbox := goring.New(int64(initialSize))


### PR DESCRIPTION
This PR exposes the User message queue length externally, via the Mailbox interface. We always had this capability in the dotnet sdk of protoactor. This field is useful in case the caller needs to check how many messages are in the user message queue prior to taking appropriate action.

Review by @rogeralsing 