### PR TITLE
Bug fixing

### DIFF
--- a/protobuf/protoc-gen-gograin/proto.go
+++ b/protobuf/protoc-gen-gograin/proto.go
@@ -110,8 +110,8 @@ func ProtoAst(file *google_protobuf.FileDescriptorProto) *ProtoFile {
 			m.PascalName = MakeFirstLowerCase(m.Name)
 			//		m.InputStream = *method.ClientStreaming
 			//		m.OutputStream = *method.ServerStreaming
-			input := removePackagePrefix(method.GetInputType(), pkg.PackageName)
-			output := removePackagePrefix(method.GetOutputType(), pkg.PackageName)
+			input := removePackagePrefix(method.GetInputType(), file.GetPackage())
+			output := removePackagePrefix(method.GetOutputType(), file.GetPackage())
 			m.Input = messages[input]
 			m.Output = messages[output]
 			s.Methods = append(s.Methods, m)

--- a/protobuf/protoc-gen-gograinv2/proto.go
+++ b/protobuf/protoc-gen-gograinv2/proto.go
@@ -110,8 +110,8 @@ func ProtoAst(file *google_protobuf.FileDescriptorProto) *ProtoFile {
 			m.PascalName = MakeFirstLowerCase(m.Name)
 			//		m.InputStream = *method.ClientStreaming
 			//		m.OutputStream = *method.ServerStreaming
-			input := removePackagePrefix(method.GetInputType(), pkg.PackageName)
-			output := removePackagePrefix(method.GetOutputType(), pkg.PackageName)
+			input := removePackagePrefix(method.GetInputType(), file.GetPackage())
+			output := removePackagePrefix(method.GetOutputType(), file.GetPackage())
 			m.Input = messages[input]
 			m.Output = messages[output]
 			s.Methods = append(s.Methods, m)


### PR DESCRIPTION
I discovered that using the package name constructed from the `option go_package` does not help to retrieve the method inputs and output name since their name is fully qualified(which is from the main package name in the protofile).