### PR TITLE
refactor: make use of the consul server address in the configuration

### DIFF
--- a/cluster/consul/options.go
+++ b/cluster/consul/options.go
@@ -15,9 +15,3 @@ func WithRefreshTTL(refreshTTL time.Duration) Option {
 		p.refreshTTL = refreshTTL
 	}
 }
-
-func WithConsulServerAddress(address string) Option {
-	return func(p *Provider) {
-		p.consulServerAddress = address
-	}
-}


### PR DESCRIPTION
This PR address an issue when the consul provider. The current behaviour is such that one will have to pass in as an option the consul server address even if it is set in the configuration before the provider can pick it. That will result in `dial tcp 127.0.0.1:8500: connect: connection refused"`. The only way to solve that is to do something like this:

```go
serverAddr := "consul.contoso.com:8600"
consul.NewWithConfig(&api.Config{Address: serverAddr}, consul.WithConsulServerAddress(serverAddr))
```
With this PR one just have to do this:

```go
serverAddr := "consul.contoso.com:8600"
consul.NewWithConfig(&api.Config{Address: serverAddr})
```