### PR TITLE
fix unseteable loggers for cluster providers #519

### DIFF
--- a/cluster/automanaged/automanaged.go
+++ b/cluster/automanaged/automanaged.go
@@ -18,7 +18,6 @@ import (
 
 //TODO: needs to be attached to the provider instance
 var (
-	plog                       = log.New(log.DebugLevel, "[CLUSTER] [AUTOMANAGED]")
 	clusterTTLErrorMutex       = new(sync.Mutex)
 	clusterMonitorErrorMutex   = new(sync.Mutex)
 	shutdownMutex              = new(sync.Mutex)

--- a/cluster/automanaged/log.go
+++ b/cluster/automanaged/log.go
@@ -1,0 +1,13 @@
+package automanaged
+
+import "github.com/AsynkronIT/protoactor-go/log"
+
+var (
+	plog = log.New(log.DebugLevel, "[CLUSTER] [AUTOMANAGED]")
+)
+
+// SetLogLevel sets the log level for the logger
+// SetLogLevel is safe to be called concurrently
+func SetLogLevel(level log.Level) {
+	plog.SetLevel(level)
+}

--- a/cluster/consul/consul_provider.go
+++ b/cluster/consul/consul_provider.go
@@ -15,7 +15,6 @@ import (
 
 var (
 	ProviderShuttingDownError = fmt.Errorf("consul cluster provider is shutting down")
-	plog                      = log.New(log.DebugLevel, "[CLUSTER] [CONSUL]")
 )
 
 type Provider struct {

--- a/cluster/consul/log.go
+++ b/cluster/consul/log.go
@@ -1,0 +1,13 @@
+package consul
+
+import "github.com/AsynkronIT/protoactor-go/log"
+
+var (
+	plog = log.New(log.DebugLevel, "[CLUSTER] [CONSUL]")
+)
+
+// SetLogLevel sets the log level for the logger
+// SetLogLevel is safe to be called concurrently
+func SetLogLevel(level log.Level) {
+	plog.SetLevel(level)
+}

--- a/cluster/etcd/etcd_provider.go
+++ b/cluster/etcd/etcd_provider.go
@@ -16,10 +16,6 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
-var (
-	plog = log.New(log.DefaultLevel, "[CLU/ETCD]")
-)
-
 type Provider struct {
 	leaseID       clientv3.LeaseID
 	cluster       *cluster.Cluster

--- a/cluster/etcd/log.go
+++ b/cluster/etcd/log.go
@@ -1,0 +1,13 @@
+package etcd
+
+import "github.com/AsynkronIT/protoactor-go/log"
+
+var (
+	plog = log.New(log.DefaultLevel, "[CLU/ETCD]")
+)
+
+// SetLogLevel sets the log level for the logger
+// SetLogLevel is safe to be called concurrently
+func SetLogLevel(level log.Level) {
+	plog.SetLevel(level)
+}

--- a/cluster/zk/log.go
+++ b/cluster/zk/log.go
@@ -1,0 +1,13 @@
+package zk
+
+import "github.com/AsynkronIT/protoactor-go/log"
+
+var (
+	plog = log.New(log.InfoLevel, "[CLU/ZK]")
+)
+
+// SetLogLevel sets the log level for the logger
+// SetLogLevel is safe to be called concurrently
+func SetLogLevel(level log.Level) {
+	plog.SetLevel(level)
+}

--- a/cluster/zk/zk_provider.go
+++ b/cluster/zk/zk_provider.go
@@ -17,8 +17,7 @@ import (
 )
 
 var (
-	_    cluster.ClusterProvider = new(Provider)
-	plog                         = log.New(log.InfoLevel, "[CLU/ZK]")
+	_ cluster.ClusterProvider = new(Provider)
 )
 
 type RoleType int


### PR DESCRIPTION
# Abstract

As reported in #519 the log levels for all cluster providers are impossible to set. This PR adds a `log.go` file to all of the aforementioned providers, moves the `plog` variable creation into it and adds an exported `SetLogLevel` function to the packages