### PR TITLE
fix: fix infinite loop in startTimer

### DIFF
--- a/_examples/scheduler/go.mod
+++ b/_examples/scheduler/go.mod
@@ -1,0 +1,10 @@
+module scheduler
+
+go 1.16
+
+replace github.com/AsynkronIT/protoactor-go => ../..
+
+require (
+	github.com/AsynkronIT/goconsole v0.0.0-20160504192649-bfa12eebf716
+	github.com/AsynkronIT/protoactor-go v0.0.0-00010101000000-000000000000
+)

--- a/_examples/scheduler/main.go
+++ b/_examples/scheduler/main.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"log"
+	"math/rand"
+	"sync"
+	"time"
+
+	console "github.com/AsynkronIT/goconsole"
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"github.com/AsynkronIT/protoactor-go/scheduler"
+)
+
+var (
+	HelloMessages []string = []string{
+		"Hello",
+		"Bonjour",
+		"Hola",
+		"Zdravstvuyte",
+		"Nǐn hǎo",
+		"Salve",
+		"Konnichiwa",
+		"Olá",
+	}
+)
+
+func main() {
+
+	var wg sync.WaitGroup
+	wg.Add(5)
+
+	rand.Seed(time.Now().UnixMicro())
+	system := actor.NewActorSystem()
+
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds)
+
+	count := 0
+	props := actor.PropsFromFunc(func(ctx actor.Context) {
+		switch t := ctx.Message().(type) {
+		case []string:
+			count++
+			log.Printf("\t%s, counter value: %d", t[rand.Intn(len(t))], count)
+			wg.Done()
+		case string:
+			log.Printf("\t%s\n", t)
+		}
+	})
+
+	pid := system.Root.Spawn(props)
+
+	s := scheduler.NewTimerScheduler(system.Root)
+	cancel := s.SendRepeatedly(1*time.Millisecond, 1*time.Millisecond, pid, HelloMessages)
+
+	wg.Wait()
+	cancel()
+
+	wg.Add(100) // add 100 to our waiting group
+	cancel = s.RequestRepeatedly(1*time.Millisecond, 1*time.Millisecond, pid, HelloMessages)
+
+	// the following timer will fire before the
+	// wait group is consumed and will stop the scheduler
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	s.SendOnce(1*time.Millisecond, pid, "Hello Once")
+
+	// this message will never show as we cancel it before it can be fired
+	cancel = s.RequestOnce(500*time.Millisecond, pid, "Hello Once Again")
+	time.Sleep(250 * time.Millisecond)
+	cancel()
+
+	_, _ = console.ReadLine()
+}

--- a/scheduler/timer.go
+++ b/scheduler/timer.go
@@ -24,10 +24,8 @@ func startTimer(delay, interval time.Duration, fn func()) CancelFunc {
 	var t *time.Timer
 	var state int32
 	t = time.AfterFunc(delay, func() {
-		state := atomic.LoadInt32(&state)
-		for state == stateInit {
+		for atomic.LoadInt32(&state) == stateInit {
 			runtime.Gosched()
-			state = atomic.LoadInt32(&state)
 		}
 
 		if state == stateDone {


### PR DESCRIPTION
# Abstract

As reported in #452, the function passed to `time.AfterFunc` can get stuck into an infinite loop if the `state` variable from the outer scope is ever equal to `stateInit` or in other words, if the body of function passed to `time.AferFunc` is executed before `atomic.StoreInt32(&state, stateReady)` in the outer scope

```go
func startTimer(delay, interval time.Duration, fn func()) CancelFunc {
	var t *time.Timer
	var state int32
	t = time.AfterFunc(delay, func() {
                 // at this point 'state' is bounded to the local scope 
                 // this will "shadow" the outer scope state var
		state := atomic.LoadInt32(&state) 
                 // we are comparing the local scope version here
		for state == stateInit {  
			runtime.Gosched()
                         // state will never be set with the value 
                         // of the outer scope one as it has been shadow
			state = atomic.LoadInt32(&state)  
		}

		if state == stateDone {
			return
		}

		fn()
		t.Reset(interval)
	})

	// ensures t != nil and is required to avoid data race in
	// AfterFunc calling t.Reset
	atomic.StoreInt32(&state, stateReady)

	return func() {
		if atomic.SwapInt32(&state, stateDone) != stateDone {
			t.Stop()
		}
	}
}
```

Although this is difficult to occur it is not impossible that the Go scheduler, schedules the goroutine running the function in the `AfterFunc` earlier than the rest of the outer body, if that happens, the function will be stuck in that loop forever as it will never be able to update the value of the local `state` variable

## PR Content

* This PR simplifies the loop making impossible for the situation to occur
* It also adds an example on how to use the scheduler package to the `_examples` directory