### PR TITLE
Expose a way to disable default stderr log

### DIFF
--- a/log/string_encoder.go
+++ b/log/string_encoder.go
@@ -50,6 +50,7 @@ func resetEventSubscriber(f func(evt Event)) {
 func (l *ioLogger) listenEvent() {
 	for true {
 		if noStdErrLogs {
+			Unsubscribe(sub)
 			break
 		}
 

--- a/log/string_encoder.go
+++ b/log/string_encoder.go
@@ -18,8 +18,18 @@ type ioLogger struct {
 }
 
 var (
-	sub *Subscription
+	noStdErrLogs bool
+	sub          *Subscription
 )
+
+// Disables Proto.Actor standard error logs if there is one
+// or more additional log subscribers registered
+func SetNoStdErrLogs() {
+
+	if len(es.subscriptions) >= 2 {
+		noStdErrLogs = true
+	}
+}
 
 func init() {
 	l := &ioLogger{c: make(chan Event, 100), out: os.Stderr}
@@ -39,6 +49,10 @@ func resetEventSubscriber(f func(evt Event)) {
 
 func (l *ioLogger) listenEvent() {
 	for true {
+		if noStdErrLogs {
+			break
+		}
+
 		e := <-l.c
 		l.writeEvent(e)
 	}


### PR DESCRIPTION
# Abstract

In some situations it might be useful to disable the default standard error output from Proto.Actor and prevent it from writing at all to any output channel. This is specially true when one is using log subscriptions to integrate Proto.Actor's logs into one's own logging solution or format.

This PR exposes a new method `SetNoStdErrLogs` to the `log` package that disables and unsubscribe the internal Proto.Actor logger (ioLogger) but only if another subscription it is in place. In case that the only subscription in place is `ioLogger` this method does nothing.

This resolves #522