### PR TITLE
fix: fix race condition in actor_metrics.go scope

### DIFF
--- a/_examples/opentelemetry-custom-provider/go.mod
+++ b/_examples/opentelemetry-custom-provider/go.mod
@@ -7,7 +7,7 @@ replace github.com/AsynkronIT/protoactor-go => ../..
 require (
 	github.com/AsynkronIT/goconsole v0.0.0-20160504192649-bfa12eebf716
 	github.com/AsynkronIT/protoactor-go v0.0.0-00010101000000-000000000000
-	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.25.0
-	go.opentelemetry.io/otel/metric v0.25.0
-	go.opentelemetry.io/otel/sdk/metric v0.25.0
+	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v0.26.0
+	go.opentelemetry.io/otel/metric v0.26.0
+	go.opentelemetry.io/otel/sdk/metric v0.26.0
 )

--- a/actor/metrics.go
+++ b/actor/metrics.go
@@ -45,7 +45,7 @@ func (m *Metrics) PrepareMailboxLengthGauge(cb metric.Int64ObserverFunc) {
 		metric.WithDescription("Actor's Mailbox Length"),
 		metric.WithUnit(unit.Dimensionless),
 	)
-	m.metrics.Instruments().ActorMailboxLength = gauge
+	m.metrics.Instruments().SetActorMailboxLengthGauge(gauge)
 }
 
 func (m *Metrics) CommonLabels(ctx Context) []attribute.KeyValue {
@@ -56,15 +56,3 @@ func (m *Metrics) CommonLabels(ctx Context) []attribute.KeyValue {
 	}
 	return labels
 }
-
-//func (m *Metrics) NewGauge() {
-//
-//}
-//
-//func (m *Metrics) NewCounter() {
-//
-//}
-//
-//func (m *Metrics) NewHistogram() {
-//
-//}


### PR DESCRIPTION
After the addition of OpenTelemetry metrics in commit 176ebb0, any piece of code that imports the `actor` package could theoretically run into a race condition so executing or testing with the `-race` flag resulted in a warning report by the go runtime.

> I say theoretically because the offending line was part of the package global scope that gets executed once when the package is imported by first time

This PR hides direct access to the `ActorMetrics.ActorMailboxLength` field that was being directly access by package scope initialization code in the `actor/props.go` file, it also adds a synchronization primitive to the ActorMetrics data structure that has to be locked in order to setup the value of the `ActorMailboxLength` field

Fixes #546