### PR TITLE
fix default config for deadletter log throttle 

### DIFF
--- a/_examples/actor-deadletter/Makefile
+++ b/_examples/actor-deadletter/Makefile
@@ -1,0 +1,2 @@
+start:
+	go run main.go -duration 20s  -rate 2000000 -throttle 3

--- a/_examples/actor-deadletter/go.mod
+++ b/_examples/actor-deadletter/go.mod
@@ -1,0 +1,11 @@
+module helloworld
+
+go 1.16
+
+replace github.com/AsynkronIT/protoactor-go => ../..
+
+require (
+	github.com/AsynkronIT/goconsole v0.0.0-20160504192649-bfa12eebf716
+	github.com/AsynkronIT/protoactor-go v0.0.0-00010101000000-000000000000
+	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
+)

--- a/_examples/actor-deadletter/main.go
+++ b/_examples/actor-deadletter/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"sync/atomic"
+	"time"
+
+	console "github.com/AsynkronIT/goconsole"
+	"github.com/AsynkronIT/protoactor-go/actor"
+	"golang.org/x/time/rate"
+)
+
+type hello struct {
+	Who string
+}
+
+func main() {
+	irate := flag.Int("rate", 1000000, "How many messages per second")
+	throttle := flag.Int("throttle", 5, "Throttle of deadletter logs")
+	d := flag.Duration("duration", 10*time.Second, "How long you want to keep sending")
+	flag.Parse()
+
+	// init
+	cfg := actor.NewConfig().
+		WithDeadLetterThrottleCount(int32(*throttle))
+	system := actor.NewActorSystemWithConfig(cfg)
+
+	btn := int32(1)
+	go func() {
+		time.Sleep(*d)
+		atomic.StoreInt32(&btn, 0)
+	}()
+
+	ctx := context.TODO()
+	invalidPid := system.NewLocalPID("unknown")
+	limiter := rate.NewLimiter(rate.Limit(*irate), *irate)
+
+	log.Printf("started")
+	for atomic.LoadInt32(&btn) == 1 {
+		system.Root.Send(invalidPid, &hello{Who: "deadleater"})
+		// time.Sleep(sleepDrt)
+		limiter.Wait(ctx)
+	}
+	log.Printf("done")
+	console.ReadLine()
+}

--- a/actor/config.go
+++ b/actor/config.go
@@ -26,8 +26,8 @@ type Config struct {
 
 func defaultActorSystemConfig() Config {
 	return Config{
-		DeadLetterThrottleInterval:  time.Duration(0),
-		DeadLetterThrottleCount:     0,
+		DeadLetterThrottleInterval:  1 * time.Second,
+		DeadLetterThrottleCount:     3,
 		DeadLetterRequestLogging:    true,
 		DeveloperSupervisionLogging: false,
 		DiagnosticsSerializer: func(actor Actor) string {

--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -3,7 +3,6 @@ package actor
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/AsynkronIT/protoactor-go/log"
@@ -24,7 +23,7 @@ func NewDeadLetter(actorSystem *ActorSystem) *deadLetterProcess {
 	}
 
 	shouldThrottle := NewThrottle(actorSystem.Config.DeadLetterThrottleCount, actorSystem.Config.DeadLetterThrottleInterval, func(i int32) {
-		plog.Info("[DeadLetter]", log.String("throttled", strconv.Itoa(int(i))))
+		plog.Info("[DeadLetter]", log.Int64("throttled", int64(i)))
 	})
 
 	actorSystem.ProcessRegistry.Add(dp, "deadletter")
@@ -41,10 +40,10 @@ func NewDeadLetter(actorSystem *ActorSystem) *deadLetterProcess {
 				return
 			}
 
-			_, isIgnoreDeadLetter := deadLetter.Message.(IgnoreDeadLetterLogging)
-
-			if (shouldThrottle() == Open) && !isIgnoreDeadLetter {
-				plog.Debug("[DeadLetter]", log.Stringer("pid", deadLetter.PID), log.TypeOf("msg", deadLetter.Message), log.Stringer("sender", deadLetter.Sender))
+			if _, isIgnoreDeadLetter := deadLetter.Message.(IgnoreDeadLetterLogging); !isIgnoreDeadLetter {
+				if shouldThrottle() == Open {
+					plog.Debug("[DeadLetter]", log.Stringer("pid", deadLetter.PID), log.TypeOf("msg", deadLetter.Message), log.Stringer("sender", deadLetter.Sender))
+				}
 			}
 		}
 	})


### PR DESCRIPTION
The deadletter log throttle is works pretty fine to me, but it lacking some default configs, so I make this PR for it.

BTW: add a example to show how it looks like.
```
$ cd _examples/actor-deadletter/
$ go run main.go -duration 10s  -rate 1000000 -throttle 3
2022/02/08 17:22:41 started
2022/02/08 17:22:41 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:41 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:42 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:42 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:42 INFO  [ACTOR]       [DeadLetter] throttled=1983780 
2022/02/08 17:22:43 INFO  [ACTOR]       [DeadLetter] throttled=1017285 
2022/02/08 17:22:43 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:43 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:44 INFO  [ACTOR]       [DeadLetter] throttled=999682 
2022/02/08 17:22:44 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:44 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:45 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:45 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:45 INFO  [ACTOR]       [DeadLetter] throttled=988167 
2022/02/08 17:22:46 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:46 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:46 INFO  [ACTOR]       [DeadLetter] throttled=1013748 
2022/02/08 17:22:47 INFO  [ACTOR]       [DeadLetter] throttled=1000118 
2022/02/08 17:22:47 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:47 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:48 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:48 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:48 INFO  [ACTOR]       [DeadLetter] throttled=980503 
2022/02/08 17:22:49 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:49 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:49 INFO  [ACTOR]       [DeadLetter] throttled=1015164 
2022/02/08 17:22:50 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:50 DEBUG [ACTOR]       [DeadLetter] pid="nonhost/unknown" msg=*main.hello sender="nil" 
2022/02/08 17:22:50 INFO  [ACTOR]       [DeadLetter] throttled=1005098 
2022/02/08 17:22:51 done
2022/02/08 17:22:51 INFO  [ACTOR]       [DeadLetter] throttled=993828
```
