### PR TITLE
refactor: improved EventStream package

### DIFF
--- a/cluster/member_list.go
+++ b/cluster/member_list.go
@@ -95,7 +95,7 @@ func (ml *MemberList) UpdateClusterTopology(members []*Member, eventId uint64) {
 	tplg := ml._updateClusterTopoLogy(members, eventId)
 
 	ml.onMembersUpdated(tplg)
-	ml.cluster.ActorSystem.EventStream.PublishUnsafe(&ClusterTopologyEventV2{
+	ml.cluster.ActorSystem.EventStream.Publish(&ClusterTopologyEventV2{
 		ClusterTopology: tplg,
 		chashByKind:     ml.chashByKind,
 	})
@@ -159,12 +159,12 @@ func (ml *MemberList) onMemberLeft(member *Member) {
 		Kinds: member.Kinds,
 	}
 	left := &MemberLeftEvent{MemberMeta: meta}
-	ml.cluster.ActorSystem.EventStream.PublishUnsafe(left)
+	ml.cluster.ActorSystem.EventStream.Publish(left)
 
 	addr := member.Address()
 	delete(ml.members, addr)
 	rt := &remote.EndpointTerminatedEvent{Address: addr}
-	ml.cluster.ActorSystem.EventStream.PublishUnsafe(rt)
+	ml.cluster.ActorSystem.EventStream.Publish(rt)
 	return
 }
 
@@ -178,7 +178,7 @@ func (ml *MemberList) onMemberJoined(member *Member) {
 		Kinds: member.Kinds,
 	}
 	joined := &MemberJoinedEvent{MemberMeta: meta}
-	ml.cluster.ActorSystem.EventStream.PublishUnsafe(joined)
+	ml.cluster.ActorSystem.EventStream.Publish(joined)
 }
 
 func (ml *MemberList) buildSortedMembers(m map[string]*Member) []*Member {

--- a/cluster/partition_manager.go
+++ b/cluster/partition_manager.go
@@ -31,13 +31,16 @@ func newPartitionManager(c *Cluster, kinds ...Kind) *PartitionManager {
 func (pm *PartitionManager) Start() {
 	system := pm.cluster.ActorSystem
 	pm.topologySub = system.EventStream.
-		Subscribe(func(ev interface{}) {
-			pm.onClusterTopology(ev.(*ClusterTopologyEventV2))
-		}).
-		WithPredicate(func(m interface{}) bool {
-			_, ok := m.(*ClusterTopologyEventV2)
-			return ok
-		})
+		SubscribeWithPredicate(
+			func(ev interface{}) {
+				pm.onClusterTopology(ev.(*ClusterTopologyEventV2))
+			},
+			func(m interface{}) bool {
+				_, ok := m.(*ClusterTopologyEventV2)
+				return ok
+			},
+		)
+
 }
 
 // Stop ...

--- a/cluster/pid_cache.go
+++ b/cluster/pid_cache.go
@@ -25,11 +25,10 @@ func setupPidCache(actorSystem *actor.ActorSystem) *pidCacheValue {
 	props := actor.PropsFromProducer(newPidCacheWatcher(pidCache)).WithGuardian(actor.RestartingSupervisorStrategy())
 	pidCache.watcher, _ = actorSystem.Root.SpawnNamed(props, "PidCacheWatcher")
 
-	pidCache.memberStatusSub = actorSystem.EventStream.Subscribe(pidCache.onMemberStatusEvent).
-		WithPredicate(func(m interface{}) bool {
-			_, ok := m.(MemberStatusEvent)
-			return ok
-		})
+	pidCache.memberStatusSub = actorSystem.EventStream.SubscribeWithPredicate(pidCache.onMemberStatusEvent, func(m interface{}) bool {
+		_, ok := m.(MemberStatusEvent)
+		return ok
+	})
 
 	return pidCache
 }

--- a/eventstream/eventstream.go
+++ b/eventstream/eventstream.go
@@ -2,98 +2,141 @@ package eventstream
 
 import (
 	"sync"
+	"sync/atomic"
 )
+
+// Handler defines a callback function that must be pass when subscribing
+type Handler func(interface{})
 
 // Predicate is a function used to filter messages before being forwarded to a subscriber
 type Predicate func(evt interface{}) bool
 
-func NewEventStream() *EventStream {
-	es := &EventStream{}
-
-	return es
-}
-
 type EventStream struct {
 	sync.RWMutex
+
+	// slice containing our subscriptors
 	subscriptions []*Subscription
+
+	// Atomically maintained elements counter
+	counter int32
 }
 
-func (es *EventStream) Subscribe(fn func(evt interface{})) *Subscription {
+// Create a new EventStream value and returns it back
+func NewEventStream() *EventStream {
+	es := EventStream{
+		subscriptions: []*Subscription{},
+	}
+
+	return &es
+}
+
+// Subscribe the given handler to the EventStream
+func (es *EventStream) Subscribe(handler Handler) *Subscription {
+
+	sub := &Subscription{
+		handler: handler,
+		active:  1,
+	}
+
 	es.Lock()
 	defer es.Unlock()
 
-	sub := &Subscription{
-		es: es,
-		i:  len(es.subscriptions),
-		fn: fn,
-	}
+	sub.id = es.counter
+	es.counter++
 	es.subscriptions = append(es.subscriptions, sub)
 	return sub
 }
 
+// SubscribeWithPredicate creates a new Subscription value and sets a predicate to filter messages passed to
+// the subscriber, it returns a pointer to the Subscription value
+func (es *EventStream) SubscribeWithPredicate(handler Handler, p Predicate) *Subscription {
+
+	sub := es.Subscribe(handler)
+	sub.p = p
+	return sub
+}
+
+// Unsubscribes the given subscription from the EventStream
 func (es *EventStream) Unsubscribe(sub *Subscription) {
-	if sub == nil || sub.i == -1 {
+
+	if sub == nil {
 		return
 	}
 
-	es.Lock()
-	defer es.Unlock()
-	// re-check, there was a twice unsubscribe somewhere.
-	if sub == nil || sub.i == -1 {
-		return
-	}
+	if sub.IsActive() {
+		es.Lock()
+		defer es.Unlock()
 
-	i := sub.i
-	l := len(es.subscriptions) - 1
+		if sub.Deactivate() {
+			if es.counter == 0 {
+				es.subscriptions = nil
+				return
+			}
 
-	if l == -1 {
-		es.subscriptions = nil
-		sub.i = -1
-		return
-	}
+			l := es.counter - 1
+			es.subscriptions[sub.id] = es.subscriptions[l]
+			es.subscriptions[sub.id].id = sub.id
+			es.subscriptions[l] = nil
+			es.subscriptions = es.subscriptions[:l]
+			es.counter--
 
-	es.subscriptions[i] = es.subscriptions[l]
-	es.subscriptions[i].i = i
-	es.subscriptions[l] = nil
-	es.subscriptions = es.subscriptions[:l]
-	sub.i = -1
-
-	// TODO(SGC): implement resizing
-	if len(es.subscriptions) == 0 {
-		es.subscriptions = nil
+			if es.counter == 0 {
+				es.subscriptions = nil
+			}
+		}
 	}
 }
 
+// Publishes the given event to all the subscribers in the stream
 func (es *EventStream) Publish(evt interface{}) {
+
 	es.RLock()
 	defer es.RUnlock()
 
-	es.PublishUnsafe(evt)
+	for _, sub := range es.subscriptions {
+		// there is a subscription predicate and it didn't pass, return
+		if sub.p != nil && !sub.p(evt) {
+			continue
+		}
+
+		// finally here, lets execute our handler
+		sub.handler(evt)
+	}
 }
 
-func (es *EventStream) PublishUnsafe(evt interface{}) {
-	for _, s := range es.subscriptions {
-		if s.p == nil || s.p(evt) {
-			s.fn(evt)
-		}
-	}
+// Returns an integer that represents the current number of subscribers to the stream
+func (es *EventStream) Length() int32 {
+
+	return atomic.LoadInt32(&es.counter)
 }
 
 // Subscription is returned from the Subscribe function.
 //
 // This value and can be passed to Unsubscribe when the observer is no longer interested in receiving messages
 type Subscription struct {
-	es *EventStream
-	i  int
-	fn func(event interface{})
-	p  Predicate
+	id      int32
+	handler Handler
+	p       Predicate
+	active  uint32
 }
 
-// WithPredicate sets a predicate to filter messages passed to the subscriber
-func (s *Subscription) WithPredicate(p Predicate) *Subscription {
-	s.es.Lock()
-	defer s.es.Unlock()
+// Activates the Subscription setting its active flag as 1, if the subscription
+// was already active it returns false, true otherwise
+func (s *Subscription) Activate() bool {
 
-	s.p = p
-	return s
+	return atomic.CompareAndSwapUint32(&s.active, 0, 1)
+}
+
+// Deactivates the Subscription setting its active flag as 0, if the subscription
+// was already inactive it returns false, true otherwise
+func (s *Subscription) Deactivate() bool {
+
+	return atomic.CompareAndSwapUint32(&s.active, 1, 0)
+}
+
+// Returns true if the active flag of the Subscription is set as 1
+// otherwise it returns false
+func (s *Subscription) IsActive() bool {
+
+	return atomic.LoadUint32(&s.active) == 1
 }

--- a/eventstream/eventstream_example_subscribe_test.go
+++ b/eventstream/eventstream_example_subscribe_test.go
@@ -9,15 +9,17 @@ import (
 // Subscribe subscribes to events
 func ExampleEventStream_Subscribe() {
 	es := eventstream.NewEventStream()
-	sub := es.Subscribe(func(event interface{}) {
+	handler := func(event interface{}) {
 		fmt.Println(event)
-	})
+	}
 
 	// only allow strings
-	sub.WithPredicate(func(evt interface{}) bool {
-		_, ok := evt.(string)
+	predicate := func(event interface{}) bool {
+		_, ok := event.(string)
 		return ok
-	})
+	}
+
+	sub := es.SubscribeWithPredicate(handler, predicate)
 
 	es.Publish("Hello World")
 	es.Publish(1)

--- a/eventstream/eventstream_test.go
+++ b/eventstream/eventstream_test.go
@@ -1,34 +1,35 @@
-package eventstream
+package eventstream_test
 
 import (
 	"testing"
 
+	"github.com/AsynkronIT/protoactor-go/eventstream"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestEventStream_Subscribe(t *testing.T) {
-	es := &EventStream{}
+	es := &eventstream.EventStream{}
 	s := es.Subscribe(func(interface{}) {})
 	assert.NotNil(t, s)
-	assert.Len(t, es.subscriptions, 1)
+	assert.Equal(t, es.Length(), int32(1))
 }
 
 func TestEventStream_Unsubscribe(t *testing.T) {
-	es := &EventStream{}
+	es := &eventstream.EventStream{}
 	var c1, c2 int
 
 	s1 := es.Subscribe(func(interface{}) { c1++ })
 	s2 := es.Subscribe(func(interface{}) { c2++ })
-	assert.Len(t, es.subscriptions, 2)
+	assert.Equal(t, es.Length(), int32(2))
 
 	es.Unsubscribe(s2)
-	assert.Len(t, es.subscriptions, 1)
+	assert.Equal(t, es.Length(), int32(1))
 
 	es.Publish(1)
 	assert.Equal(t, 1, c1)
 
 	es.Unsubscribe(s1)
-	assert.Empty(t, es.subscriptions)
+	assert.Equal(t, es.Length(), int32(0))
 
 	es.Publish(1)
 	assert.Equal(t, 1, c1)
@@ -36,7 +37,7 @@ func TestEventStream_Unsubscribe(t *testing.T) {
 }
 
 func TestEventStream_Publish(t *testing.T) {
-	es := &EventStream{}
+	es := &eventstream.EventStream{}
 
 	var v int
 	es.Subscribe(func(m interface{}) { v = m.(int) })
@@ -50,9 +51,11 @@ func TestEventStream_Publish(t *testing.T) {
 
 func TestEventStream_Subscribe_WithPredicate_IsCalled(t *testing.T) {
 	called := false
-	es := &EventStream{}
-	es.Subscribe(func(interface{}) { called = true }).
-		WithPredicate(func(m interface{}) bool { return true })
+	es := &eventstream.EventStream{}
+	es.SubscribeWithPredicate(
+		func(interface{}) { called = true },
+		func(m interface{}) bool { return true },
+	)
 	es.Publish("")
 
 	assert.True(t, called)
@@ -60,10 +63,40 @@ func TestEventStream_Subscribe_WithPredicate_IsCalled(t *testing.T) {
 
 func TestEventStream_Subscribe_WithPredicate_IsNotCalled(t *testing.T) {
 	called := false
-	es := &EventStream{}
-	es.Subscribe(func(interface{}) { called = true }).
-		WithPredicate(func(m interface{}) bool { return false })
+	es := &eventstream.EventStream{}
+	es.SubscribeWithPredicate(
+		func(interface{}) { called = true },
+		func(m interface{}) bool { return false },
+	)
 	es.Publish("")
 
 	assert.False(t, called)
+}
+
+type Event struct {
+	i int
+}
+
+func BenchmarkEventStream(b *testing.B) {
+
+	es := eventstream.NewEventStream()
+	subs := make([]*eventstream.Subscription, 10)
+	for i := 0; i < b.N; i++ {
+		for j := 0; j < 10; j++ {
+			sub := es.Subscribe(func(evt interface{}) {
+				if e := evt.(*Event); e.i != i {
+					b.Fatalf("expected i to be %d but its value is %d", i, e.i)
+				}
+			})
+			subs[j] = sub
+		}
+
+		es.Publish(&Event{i: i})
+		for j := range subs {
+			es.Unsubscribe(subs[j])
+			if subs[j].IsActive() {
+				b.Fatal("subscription should not be active")
+			}
+		}
+	}
 }

--- a/remote/endpoint_manager.go
+++ b/remote/endpoint_manager.go
@@ -77,8 +77,7 @@ func newEndpointManager(r *Remote) *endpointManager {
 func (em *endpointManager) start() {
 	eventStream := em.remote.actorSystem.EventStream
 	em.endpointSub = eventStream.
-		Subscribe(em.endpointEvent).
-		WithPredicate(func(m interface{}) bool {
+		SubscribeWithPredicate(em.endpointEvent, func(m interface{}) bool {
 			switch m.(type) {
 			case *EndpointTerminatedEvent, *EndpointConnectedEvent:
 				return true


### PR DESCRIPTION
# Abstract 

This PR is a small refactor of the `EventStream` package to improve its safety, idioms and API. It will also settle ongoing discussion in #376 about the inclusion of the `PublishUnsafe` in #371

## Changes

* Made `EventStream` to embed `sync.RWMutex`
* Removed `EventStream` direct access from `Subscription`
* Made `EventStream` an immutable value moving `WithPredicate` from being an `EventStream` method into being an specialized constructor,  this prevents race conditions and/or deadlocks from Predicates accessing the  `EventStream` value itself from their own contexts
* Made `Subscription` concurrently safe
* `PublishUnsafe` is gone and now only safe publishes are allowed

## Implementation Details

There are some details to take into account about these changes. 

1. `Subscription` values **can not** access the `EventStream` directly as their `es` field has been removed, if anyone was using this for anything, that I doubt, please raise your concerns about it
2. The third bullet point above makes this kind of an API breaking change, users of the library that use `EventStream` in their own projects and are used to use `eventstream.WithPredicate` method needs to update to the new API, this is pretty easy and it is described below

### Updating WithPredicate code

This old idiom:   
```go
sub := sys.EventStream.Subscribe(func(ev interface{}) { 
    /* do something here */
}).WithPredicate(func(m interface{}) bool { 
    /* do something else here that return a bool value */
})
```

Becomes:
```go
sub := sys.EventStream.SubscribeWithPredicate(
    func(ev interface{}) {
        /* do something here */
    },
    func(ev interface{}) bool {
        /* do something else here that return a bool value */
    },
)
```

This means, the predicate can not be changed after it is set in the construction of the Subscription value.

## Performance Considerations
There is a marginal performance impact compared with the previous version, it is small enough as to not even consider it, below the best result of one hundred benchmark runs

Old implementation:   
```
goos: linux
goarch: amd64
pkg: github.com/AsynkronIT/protoactor-go/eventstream
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkEventStream-12           735937              1514 ns/op             816 B/op         26 allocs/op
PASS
```
New implementation:   
```
goos: linux
goarch: amd64
pkg: github.com/AsynkronIT/protoactor-go/eventstream
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkEventStream-12           715729              1552 ns/op             816 B/op         26 allocs/op
PASS
```

