### PR TITLE
fix: fix use of obsolete PublishUnsafe

### DIFF
--- a/cluster/member_list.go
+++ b/cluster/member_list.go
@@ -231,7 +231,7 @@ func (ml *MemberList) onMemberLeft(member *Member) {
 	addr := member.Address()
 	delete(ml.members, addr)
 	rt := &remote.EndpointTerminatedEvent{Address: addr}
-	ml.cluster.ActorSystem.EventStream.PublishUnsafe(rt)
+	ml.cluster.ActorSystem.EventStream.Publish(rt)
 }
 
 func (ml *MemberList) onMemberJoined(member *Member) {


### PR DESCRIPTION
# Abstract 
Unfortunately, applying #560 after #561 reverted one of the updates from `PublishUnsafe` to `Publish`  this PR fixes it

## Additional Information
The original git diff where this change was been firstly applied in #561 can be found in [this link](https://github.com/asynkron/protoactor-go/commit/4a89a5af09be6bb4272db67bd5154a9bad289e3d#diff-1c414ef003f4331f6e62856edd2e8a0f502e3d882299e0ff1ce39ce3bf7a2625R167)

The diff where it is reverted back by #560 can be found in [this other link](https://github.com/asynkron/protoactor-go/pull/560/files#diff-1c414ef003f4331f6e62856edd2e8a0f502e3d882299e0ff1ce39ce3bf7a2625R234)