### PR TITLE
[DO NOT MERGE YET] fix: pass Watch system message to inner.ReceiveDefault

### DIFF
--- a/protobuf/protoc-gen-gograinv2/template.go
+++ b/protobuf/protoc-gen-gograinv2/template.go
@@ -116,11 +116,12 @@ func (a *{{ $service.Name }}Actor) Receive(ctx actor.Context) {
 		ctx.Poison(ctx.Self())
 
 	case actor.AutoReceiveMessage: // pass
-	case actor.SystemMessage: 
-		if _, ok := msg.(*actor.Watch); ok {
-			// give a chance to the inner implementations to catch Watch messages
+	case actor.SystemMessage:
+		switch msg.(type) {
+		case *actor.Watch, *actor.Unwatch:
+			// give a chance to the inner implementations to catch Watch and Unwatch messages
 			a.inner.ReceiveDefault(ctx)
-		}
+		} 
 	case *cluster.GrainRequest:
 		switch msg.MethodIndex {
 		{{ range $method := $service.Methods -}}

--- a/protobuf/protoc-gen-gograinv2/template.go
+++ b/protobuf/protoc-gen-gograinv2/template.go
@@ -116,8 +116,11 @@ func (a *{{ $service.Name }}Actor) Receive(ctx actor.Context) {
 		ctx.Poison(ctx.Self())
 
 	case actor.AutoReceiveMessage: // pass
-	case actor.SystemMessage: // pass
-
+	case actor.SystemMessage: 
+		if _, ok := msg.(*actor.Watch); ok {
+			// give a chance to the inner implementations to catch Watch messages
+			a.inner.ReceiveDefault(ctx)
+		}
 	case *cluster.GrainRequest:
 		switch msg.MethodIndex {
 		{{ range $method := $service.Methods -}}


### PR DESCRIPTION
# Abstract 

The protoc-gen-gograin boilerplate generation swallows any `SystemMessage`'s that comes to the grains, this is fine in the traditional sense of the grain lifecycle being already managed but in some situations, like with the `Watch` message we might be interested in handle the message in the inner implementation

## (partial?) Solution

I added a small conditional to send the `actor.Watch` and `actor.Unwatch` events to the inner implementation `ReceiveDefault` hook method. We might be interested in also pass other system messages.

## Backward compatibility

The change is backward compatible in the sense that no code built with older versions of `protoc-gen-gograin` is gonna stop working, simply, grain inner implementations that have been compiled with older version boilerplate code will not catch Watch and Unwatch at all that will be completely fine 