### PR TITLE
fix: fix captured state in closure on gossiper

### DIFF
--- a/cluster/gossiper.go
+++ b/cluster/gossiper.go
@@ -55,8 +55,6 @@ func newGossiper(cl *Cluster, opts ...Option) (Gossiper, error) {
 		close:           make(chan struct{}),
 	}
 
-	gossiper.throttler = actor.NewThrottle(3, 60*time.Second, gossiper.throttledLog)
-
 	// apply any given options
 	for _, opt := range opts {
 		opt(&gossiper)
@@ -203,6 +201,7 @@ func (g *Gossiper) StartGossiping() error {
 		}
 	})
 	plog.Info("Started Cluster Gossip")
+	g.throttler = actor.NewThrottle(3, 60*time.Second, g.throttledLog)
 	go g.gossipLoop()
 
 	return nil
@@ -238,5 +237,5 @@ breakLoop:
 
 func (g *Gossiper) throttledLog(counter int32) {
 
-	plog.Info(fmt.Sprintf("[Gossiper] Gossiper Setting State to %s", g.pid), log.Int("throttled", int(counter)))
+	plog.Debug(fmt.Sprintf("[Gossiper] Gossiper Setting State to %s", g.pid), log.Int("throttled", int(counter)))
 }

--- a/cluster/informer.go
+++ b/cluster/informer.go
@@ -294,5 +294,5 @@ func (inf *Informer) commitPendingOffsets(offsets map[string]int64) {
 
 func (inf *Informer) throttledLog(counter int32) {
 
-	plog.Info("[Gossip] Setting State", log.Int("throttled", int(counter)))
+	plog.Debug("[Gossip] Setting State", log.Int("throttled", int(counter)))
 }


### PR DESCRIPTION
# Abstract

The gossiper throttling was being set up before the gossiper value had a valid PID as it was capturing the value before the spawning  of the factory, this MR moves the throttling initialization after  the gossiper has been properly initialized so its PID is properly set and it can be seen in message logs

Also demoted the gossiper messages from Info to Debug