### PR TITLE
Prevent grain protogen from trying to generate code for includes

### DIFF
--- a/protobuf/protoc-gen-gograinv2/main.go
+++ b/protobuf/protoc-gen-gograinv2/main.go
@@ -23,6 +23,10 @@ func removePackagePrefix(name string, pname string) string {
 func generateCode(req *plugin.CodeGeneratorRequest, filenameSuffix string, goFmt bool) *plugin.CodeGeneratorResponse {
 	response := &plugin.CodeGeneratorResponse{}
 	for _, f := range req.GetProtoFile() {
+		if inStringSlice(f.GetName(), req.FileToGenerate) {
+			continue
+		}
+
 		s := generate(f)
 
 		// we only generate grains for proto files containing valid service definition
@@ -38,6 +42,15 @@ func generateCode(req *plugin.CodeGeneratorRequest, filenameSuffix string, goFmt
 	}
 
 	return response
+}
+
+func inStringSlice(val string, ss []string) bool {
+	for _, s := range ss {
+		if val == s {
+			return true
+		}
+	}
+	return false
 }
 
 func generate(file *google_protobuf.FileDescriptorProto) string {

--- a/protobuf/protoc-gen-gograinv2/main.go
+++ b/protobuf/protoc-gen-gograinv2/main.go
@@ -23,7 +23,7 @@ func removePackagePrefix(name string, pname string) string {
 func generateCode(req *plugin.CodeGeneratorRequest, filenameSuffix string, goFmt bool) *plugin.CodeGeneratorResponse {
 	response := &plugin.CodeGeneratorResponse{}
 	for _, f := range req.GetProtoFile() {
-		if inStringSlice(f.GetName(), req.FileToGenerate) {
+		if !inStringSlice(f.GetName(), req.FileToGenerate) {
 			continue
 		}
 


### PR DESCRIPTION
The grain generator is currently ignoring FileToGenerate passed to by protoc. This means it will try to generate grain code also based on the files that were include in the actual proto file given as input.

So something like

```sh
$ protoc -I ../protos-for-grpc --gograinv2_out=. grain.proto
```
will attempt to generate grains for all the files included in `grain.proto` from the `../protos-for-grpc` include directory.

I ran into multiple issues (https://github.com/asynkron/protoactor-go/issues/648) with the grain protogen with this one being the only one with no viable workaround and also prevents using the workarounds listed for the other issues. So fixing this one first.

