### PR TITLE
Fix zookeeper provider on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,4 +398,4 @@ Our awesome sponsors:
   <img src="https://contributors-img.web.app/image?repo=asynkron/protoactor-go" />
 </a>
 
-Made with [contributors-img](https://contributors-img.web.app).
+Made with [contributors-img](https://contributors-img.web.app). 

--- a/README.md
+++ b/README.md
@@ -121,23 +121,8 @@ This command exectutes all tests in the repository except for consul integration
 those tests). We also skip directories that don't contain any tests.
 
 ```
-go test `go list ./... | grep -v consul` | grep -v 'no test files'
+go test `go list ./... | grep -v "/_examples/" | grep -v "/persistence" | grep -v "/scheduler"`
 ```
-
-If everything is ok, you will get the output:
-
-```
-ok  	github.com/asynkron/protoactor-go/actor	0.115s
-ok  	github.com/asynkron/protoactor-go/eventstream	0.020s
-ok  	github.com/asynkron/protoactor-go/internal/queue/goring	2.524s
-ok  	github.com/asynkron/protoactor-go/internal/queue/mpsc	2.385s
-ok  	github.com/asynkron/protoactor-go/log	0.017s
-ok  	github.com/asynkron/protoactor-go/mailbox	2.742s
-ok  	github.com/asynkron/protoactor-go/plugin	1.227s
-ok  	github.com/asynkron/protoactor-go/router	1.836s
-ok  	github.com/asynkron/protoactor-go/stream	0.017s
-```
-
 ## Hello world
 
 ```go

--- a/cluster/clusterproviders/zk/utils.go
+++ b/cluster/clusterproviders/zk/utils.go
@@ -69,3 +69,15 @@ func getRunTimeStack() []byte {
 	buf := make([]byte, size)
 	return buf[:runtime.Stack(buf, false)]
 }
+
+func getParentDir(path string) string {
+	parent := path[:strings.LastIndex(path, "/")]
+	if parent == "" {
+		return "/"
+	}
+	return parent
+}
+
+func joinPath(paths ...string) string {
+	return strings.Join(paths, "/")
+}

--- a/cluster/clusterproviders/zk/zk_provider_test.go
+++ b/cluster/clusterproviders/zk/zk_provider_test.go
@@ -63,13 +63,16 @@ func (suite *ZookeeperTestSuite) TestMultiNodes() {
 	helloKind := cluster.NewKind("hello", props)
 
 	name := `cluster1`
-	c := suite.start(name, cluster.WithKinds(helloKind))
-	defer c.Shutdown()
 	c1 := suite.start(name, cluster.WithKinds(helloKind))
 	defer c1.Shutdown()
-	c.Cluster.Get(`a1`, `hello`)
-	c1.Cluster.Get(`a2`, `hello`)
+	c2 := suite.start(name, cluster.WithKinds(helloKind))
+	defer c2.Shutdown()
+	c1.Cluster.Get(`a1`, `hello`)
+	c2.Cluster.Get(`a2`, `hello`)
 	for actorCount != 2 {
 		time.Sleep(time.Microsecond * 5)
 	}
+	suite.Assert().Equal(2, c1.Cluster.MemberList.Members().Len(), "Expected 2 members in the cluster")
+	suite.Assert().Equal(2, c2.Cluster.MemberList.Members().Len(), "Expected 2 members in the cluster")
+
 }


### PR DESCRIPTION
Paths produced by go `filepath` package on Windows are incorrect from Zookeeper's perspective. Replaced with custom path code.