### PR TITLE
fixing hasher is not consistent when getting multiple request at the same time

### DIFF
--- a/cluster/rendezvous.go
+++ b/cluster/rendezvous.go
@@ -15,15 +15,15 @@ type memberData struct {
 	hashBytes []byte
 }
 type Rendezvous struct {
-	mutex   sync.RWMutex
-	hasher  hash.Hash32
-	members []*memberData
+	mutex      sync.RWMutex
+	makeHasher func() hash.Hash32
+	members    []*memberData
 }
 
 func NewRendezvous() *Rendezvous {
 	return &Rendezvous{
-		hasher:  fnv.New32a(),
-		members: make([]*memberData, 0),
+		makeHasher: func() hash.Hash32 { return fnv.New32a() },
+		members:    make([]*memberData, 0),
 	}
 }
 
@@ -126,8 +126,9 @@ func (r *Rendezvous) UpdateMembers(members Members) {
 }
 
 func (r *Rendezvous) hash(node, key []byte) uint32 {
-	r.hasher.Reset()
-	r.hasher.Write(key)
-	r.hasher.Write(node)
-	return r.hasher.Sum32()
+	h := r.makeHasher()
+	h.Reset()
+	h.Write(key)
+	h.Write(node)
+	return h.Sum32()
 }


### PR DESCRIPTION
GetByClusterIdentity() is protected by RLock but multiple read request can be called as it is read lock.
And fnv.New32a is not thread safe hasher so hasher.Write() function can be called at the same time and hash result is inconsistent.

so that messages can be sent to wrong cluster.

I changed to make new hasher every time it called and fnv.New32a() has very light weight so I think it is fine for performance as well. only problem can be increasing GC count but hasher is not escape from hash() function so I think it is allocated in stack memory so I think GC count will be not increased.

I added test case for verifying this problem. without this change, the test will be failed.