### PR TITLE
_examples  persistence protobuf update version #808

### DIFF
--- a/_examples/persistence/go.mod
+++ b/_examples/persistence/go.mod
@@ -7,4 +7,5 @@ replace github.com/asynkron/protoactor-go => ../..
 require (
 	github.com/asynkron/goconsole v0.0.0-20160504192649-bfa12eebf716
 	github.com/asynkron/protoactor-go v0.0.0-00010101000000-000000000000
+	google.golang.org/protobuf v1.28.1
 )

--- a/_examples/persistence/main.go
+++ b/_examples/persistence/main.go
@@ -8,6 +8,11 @@ import (
 	console "github.com/asynkron/goconsole"
 	"github.com/asynkron/protoactor-go/actor"
 	"github.com/asynkron/protoactor-go/persistence"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/runtime/protoiface"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 type Provider struct {
@@ -39,7 +44,11 @@ func (p *Provider) GetState() persistence.ProviderState {
 	return p.providerState
 }
 
-type protoMsg struct{ state string }
+type protoMsg struct {
+	state string
+	set   bool
+	value string
+}
 
 func (p *protoMsg) Reset()         {}
 func (p *protoMsg) String() string { return p.state }
@@ -49,6 +58,121 @@ type (
 	Message  struct{ protoMsg }
 	Snapshot struct{ protoMsg }
 )
+
+func (m *protoMsg) ProtoReflect() protoreflect.Message { return (*message)(m) }
+
+type message protoMsg
+
+type messageType struct{}
+
+func (messageType) New() protoreflect.Message                  { return &message{} }
+func (messageType) Zero() protoreflect.Message                 { return (*message)(nil) }
+func (messageType) Descriptor() protoreflect.MessageDescriptor { return fileDesc.Messages().Get(0) }
+
+func (m *message) New() protoreflect.Message                  { return &message{} }
+func (m *message) Descriptor() protoreflect.MessageDescriptor { return fileDesc.Messages().Get(0) }
+func (m *message) Type() protoreflect.MessageType             { return messageType{} }
+func (m *message) Interface() protoreflect.ProtoMessage       { return (*protoMsg)(m) }
+func (m *message) ProtoMethods() *protoiface.Methods          { return nil }
+
+var fieldDescS = fileDesc.Messages().Get(0).Fields().Get(0)
+
+func (m *message) Range(f func(protoreflect.FieldDescriptor, protoreflect.Value) bool) {
+	if m.set {
+		f(fieldDescS, protoreflect.ValueOf(m.value))
+	}
+}
+
+func (m *message) Has(fd protoreflect.FieldDescriptor) bool {
+	if fd == fieldDescS {
+		return m.set
+	}
+	panic("invalid field descriptor")
+}
+
+func (m *message) Clear(fd protoreflect.FieldDescriptor) {
+	if fd == fieldDescS {
+		m.value = ""
+		m.set = false
+		return
+	}
+	panic("invalid field descriptor")
+}
+
+func (m *message) Get(fd protoreflect.FieldDescriptor) protoreflect.Value {
+	if fd == fieldDescS {
+		return protoreflect.ValueOf(m.value)
+	}
+	panic("invalid field descriptor")
+}
+
+func (m *message) Set(fd protoreflect.FieldDescriptor, v protoreflect.Value) {
+	if fd == fieldDescS {
+		m.value = v.String()
+		m.set = true
+		return
+	}
+	panic("invalid field descriptor")
+}
+
+func (m *message) Mutable(protoreflect.FieldDescriptor) protoreflect.Value {
+	panic("invalid field descriptor")
+}
+
+func (m *message) NewField(protoreflect.FieldDescriptor) protoreflect.Value {
+	panic("invalid field descriptor")
+}
+
+func (m *message) WhichOneof(protoreflect.OneofDescriptor) protoreflect.FieldDescriptor {
+	panic("invalid oneof descriptor")
+}
+
+func (m *message) GetUnknown() protoreflect.RawFields { return nil }
+
+// func (m *message) SetUnknown(protoreflect.RawFields)  { return }
+func (m *message) SetUnknown(protoreflect.RawFields) {}
+
+func (m *message) IsValid() bool {
+	return m != nil
+}
+
+var fileDesc = func() protoreflect.FileDescriptor {
+	p := &descriptorpb.FileDescriptorProto{}
+	if err := prototext.Unmarshal([]byte(descriptorText), p); err != nil {
+		panic(err)
+	}
+	file, err := protodesc.NewFile(p, nil)
+	if err != nil {
+		panic(err)
+	}
+	return file
+}()
+
+const descriptorText = `
+  name: "internal/testprotos/irregular/irregular.proto"
+  package: "goproto.proto.thirdparty"
+  message_type {
+    name: "IrregularMessage"
+    field {
+      name: "s"
+      number: 1
+      label: LABEL_OPTIONAL
+      type: TYPE_STRING
+      json_name: "s"
+    }
+  }
+  options {
+    go_package: "google.golang.org/protobuf/internal/testprotos/irregular"
+  }
+`
+
+type AberrantMessage int
+
+func (m AberrantMessage) ProtoMessage()            {}
+func (m AberrantMessage) Reset()                   {}
+func (m AberrantMessage) String() string           { return "" }
+func (m AberrantMessage) Marshal() ([]byte, error) { return nil, nil }
+func (m AberrantMessage) Unmarshal([]byte) error   { return nil }
 
 type Actor struct {
 	persistence.Mixin


### PR DESCRIPTION
_examples/persistence/main.go

```zsh
2023/02/20 22:04:24 actor started
2023/02/20 22:04:24 recovered from snapshot, internal state changed to 'state2'
2023/02/20 22:04:24 received replayed event, internal state changed to 'state3'
2023/02/20 22:04:24 replay completed, internal state changed to 'state3'
2023/02/20 22:04:24 received new message, internal state changed to 'state4'
2023/02/20 22:04:24 received new message, internal state changed to 'state5'
*** restart ***
2023/02/20 22:04:24 actor started
2023/02/20 22:04:24 recovered from snapshot, internal state changed to 'state2'
2023/02/20 22:04:24 received replayed event, internal state changed to 'state3'
2023/02/20 22:04:24 received replayed event, internal state changed to 'state4'
2023/02/20 22:04:24 received replayed event, internal state changed to 'state5'
2023/02/20 22:04:24 replay completed, internal state changed to 'state5'
```