### PR TITLE
Ported the ability to cancel long-running tasks in actors

### DIFF
--- a/actor/context.go
+++ b/actor/context.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	"context"
 	"time"
 
 	"github.com/asynkron/protoactor-go/ctxext"
@@ -91,6 +92,9 @@ type basePart interface {
 	Forward(pid *PID)
 
 	ReenterAfter(f *Future, continuation func(res interface{}, err error))
+
+	// Ctx Pass this to long-running tasks to stop them when the actor is about to stop
+	Ctx() context.Context
 }
 
 type messagePart interface {

--- a/actor/mailbox.go
+++ b/actor/mailbox.go
@@ -21,6 +21,7 @@ type MessageInvoker interface {
 	InvokeSystemMessage(interface{})
 	InvokeUserMessage(interface{})
 	EscalateFailure(reason interface{}, message interface{})
+	cancelContext()
 }
 
 // Mailbox interface is used to enqueue messages to the mailbox
@@ -98,6 +99,11 @@ func (m *defaultMailbox) PostSystemMessage(message interface{}) {
 	}
 	m.systemMailbox.Push(message)
 	atomic.AddInt32(&m.sysMessages, 1)
+	// check if message is stop
+	if _, ok := message.(*Stop); ok {
+		m.invoker.cancelContext()
+	}
+
 	m.schedule()
 }
 

--- a/actor/mailbox_test.go
+++ b/actor/mailbox_test.go
@@ -19,6 +19,9 @@ type invoker struct {
 	wg    *sync.WaitGroup
 }
 
+func (i *invoker) cancelContext() {
+}
+
 func (i *invoker) InvokeSystemMessage(interface{}) {
 	i.count++
 	if i.count == i.max {

--- a/router/common_test.go
+++ b/router/common_test.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,6 +28,11 @@ type mockContext struct {
 //
 // Interface: Context
 //
+
+func (m *mockContext) Ctx() context.Context {
+	args := m.Called()
+	return args.Get(0).(context.Context)
+}
 
 func (m *mockContext) Get(id ctxext.ContextExtensionID) ctxext.ContextExtension {
 	args := m.Called(id)


### PR DESCRIPTION
### Summary

Ported the `CancellationToken` pattern used in dotnet and exposed `context.Context`  as `Ctx()` on the actor context. 
This should make easier to cancel long running operations in actors gracefully when stopping.