### PR TITLE
Optimize PIDSet performance

### DIFF
--- a/actor/pidset_test.go
+++ b/actor/pidset_test.go
@@ -1,6 +1,7 @@
 package actor
 
 import (
+	"math/rand"
 	"strconv"
 	"testing"
 
@@ -21,6 +22,18 @@ func TestPIDSet_Clear(t *testing.T) {
 	s.Clear()
 	assert.True(t, s.Empty())
 	assert.Len(t, s.pids, 0)
+}
+
+func TestPIDSet_Remove(t *testing.T) {
+	var s PIDSet
+	s.Add(NewPID(localAddress, "p1"))
+	s.Add(NewPID(localAddress, "p2"))
+	s.Add(NewPID(localAddress, "p3"))
+	assert.Equal(t, 3, s.Len())
+
+	s.Remove(NewPID(localAddress, "p3"))
+	assert.Equal(t, 2, s.Len())
+	assert.False(t, s.Contains(NewPID(localAddress, "p3")))
 }
 
 func TestPIDSet_AddSmall(t *testing.T) {
@@ -57,7 +70,7 @@ func TestPIDSet_AddMap(t *testing.T) {
 var pids []*PID
 
 func init() {
-	for i := 0; i < 1000; i++ {
+	for i := 0; i < 100000; i++ {
 		pids = append(pids, NewPID(localAddress, "p"+strconv.Itoa(i)))
 	}
 }
@@ -114,5 +127,38 @@ func pidSetAddRemove(b *testing.B, data []*PID) {
 		for j := 0; j < len(data); j++ {
 			s.Remove(data[j])
 		}
+	}
+}
+
+func BenchmarkPIDSet(b *testing.B) {
+	cases := []struct {
+		l int
+	}{
+		{l: 1},
+		{l: 5},
+		{l: 20},
+		{l: 500},
+		{l: 1000},
+		{l: 10000},
+		{l: 100000},
+	}
+
+	for _, tc := range cases {
+		b.Run("len "+strconv.Itoa(tc.l), func(b *testing.B) {
+			b.StopTimer()
+			var s PIDSet
+			for i := 0; i < tc.l; i++ {
+				s.Add(pids[i])
+			}
+			b.StartTimer()
+
+			for i := 0; i < b.N; i++ {
+				pid := pids[rand.Intn(len(pids))]
+
+				s.Add(pid)
+
+				s.Remove(s.Get(rand.Intn(s.Len())))
+			}
+		})
 	}
 }


### PR DESCRIPTION
This PR introduces several changes to the PIDSet implementation, resulting in improved performance and reduced memory allocations.

* The lookup map in the PIDSet struct now uses a pidKey struct as a key instead of a string. This change eliminates the need for string formatting and thus reduces memory allocations.
* The indexOf method now uses the lookup map to find the index of the specified PID directly, making it more efficient.
* The Remove method has been optimized to avoid the creation of a new slice. Instead, it replaces the removed PID with the last PID in the pids slice and updates the lookup map accordingly.
* The pidset_test.go file has been updated with a new test for the Remove method and more comprehensive benchmarks that cover different set sizes.

These changes should improve the overall performance of the PIDSet and reduce memory allocations, making the library more efficient and lightweight.

<details><summary>Benchmarks</summary>

### Original implementation
```
goos: darwin
goarch: amd64
pkg: github.com/asynkron/protoactor-go/actor
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkPIDSet
BenchmarkPIDSet/len_1
BenchmarkPIDSet/len_1-12         	 1375432	       740.3 ns/op	     144 B/op	       9 allocs/op
BenchmarkPIDSet/len_5
BenchmarkPIDSet/len_5-12         	 1594579	       721.9 ns/op	     144 B/op	       9 allocs/op
BenchmarkPIDSet/len_20
BenchmarkPIDSet/len_20-12        	 1581361	       732.4 ns/op	     144 B/op	       9 allocs/op
BenchmarkPIDSet/len_500
BenchmarkPIDSet/len_500-12       	  923178	      1169 ns/op	     144 B/op	       8 allocs/op
BenchmarkPIDSet/len_1000
BenchmarkPIDSet/len_1000-12      	  914745	      1112 ns/op	     144 B/op	       8 allocs/op
BenchmarkPIDSet/len_10000
BenchmarkPIDSet/len_10000-12     	   44992	     32307 ns/op	     142 B/op	       8 allocs/op
BenchmarkPIDSet/len_100000
BenchmarkPIDSet/len_100000-12    	    4071	    343884 ns/op	      96 B/op	       6 allocs/op
```


### Updated implementation
```
goos: darwin
goarch: amd64
pkg: github.com/asynkron/protoactor-go/actor
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkPIDSet
BenchmarkPIDSet/len_1
BenchmarkPIDSet/len_1-12         	 4889827	       247.1 ns/op	       0 B/op	       0 allocs/op
BenchmarkPIDSet/len_5
BenchmarkPIDSet/len_5-12         	 4651048	       258.0 ns/op	       0 B/op	       0 allocs/op
BenchmarkPIDSet/len_20
BenchmarkPIDSet/len_20-12        	 4052954	       287.8 ns/op	       0 B/op	       0 allocs/op
BenchmarkPIDSet/len_500
BenchmarkPIDSet/len_500-12       	 4052511	       312.5 ns/op	       0 B/op	       0 allocs/op
BenchmarkPIDSet/len_1000
BenchmarkPIDSet/len_1000-12      	 3820195	       273.4 ns/op	       0 B/op	       0 allocs/op
BenchmarkPIDSet/len_10000
BenchmarkPIDSet/len_10000-12     	 3478447	       301.7 ns/op	       0 B/op	       0 allocs/op
BenchmarkPIDSet/len_100000
BenchmarkPIDSet/len_100000-12    	 3048384	       379.0 ns/op	       0 B/op	       0 allocs/op
```
</details> 

The downside of these changes is that Remove() method now changes the order of elements in the set. It can affect distribution for the round-robin router. But as I can see router usually has a fixed set of routees so It should be fine.

I need this fix because I have a registry actor which can have up to 100k children that spawns and destroys dynamically. And method removeChild causes a significant load.

<details><summary>CPU Profile of my production application</summary>
<img width="1550" alt="image" src="https://user-images.githubusercontent.com/5724853/231747033-bd12a9b4-fb74-45ee-b379-a53abf6418d3.png">

</details> 


