### PR TITLE
Fixes race condition in EventStream

### DIFF
--- a/eventstream/eventstream.go
+++ b/eventstream/eventstream.go
@@ -111,7 +111,9 @@ func (es *EventStream) Publish(evt interface{}) {
 
 // Returns an integer that represents the current number of subscribers to the stream
 func (es *EventStream) Length() int32 {
-	return atomic.LoadInt32(&es.counter)
+	es.RLock()
+	defer es.RUnlock()
+	return es.counter
 }
 
 // Subscription is returned from the Subscribe function.


### PR DESCRIPTION
Locks the mutex for reading when getting Length(). I am hoping this will solve the following data race `go test` is reporting:

```
WARNING: DATA RACE
Read at 0x00c000224a30 by goroutine 5563:
  sync/atomic.LoadInt32()
      /opt/hostedtoolcache/go/1.20.6/x64/src/runtime/race_amd64.s:202 +0xb
  sync/atomic.LoadInt32()
      <autogenerated>:1 +0x16
  github.com/asynkron/protoactor-go/actor.(*deadLetterProcess).SendSystemMessage()
      /home/runner/go/pkg/mod/github.com/asynkron/protoactor-go@v0.0.0-20230703103118-df5e4f42621c/actor/deadletter.go:97 +0x18c
  github.com/asynkron/protoactor-go/actor.(*deadLetterProcess).Stop()
      /home/runner/go/pkg/mod/github.com/asynkron/protoactor-go@v0.0.0-20230703103118-df5e4f42621c/actor/deadletter.go:104 +0x2c
  github.com/asynkron/protoactor-go/actor.(*actorContext).Stop()
      /home/runner/go/pkg/mod/github.com/asynkron/protoactor-go@v0.0.0-20230703103118-df5e4f42621c/actor/actor_context.go:436 +0x298
...

Previous write at 0x00c000224a30 by goroutine 5570:
  github.com/asynkron/protoactor-go/eventstream.(*EventStream).Subscribe()
      /home/runner/go/pkg/mod/github.com/asynkron/protoactor-go@v0.0.0-20230703103118-df5e4f42621c/eventstream/eventstream.go:44 +0x1e4
...
```

I am assuming the atomic read was supposed to protect against? But if the write isn't atomic I think there is still the potential for issues. As I understand it read and write should either both use the mutex (as in this PR) or ensure that all operations are atomic.