### PR TITLE
Inverse children stopping order.

### DIFF
--- a/actor/actor_context.go
+++ b/actor/actor_context.go
@@ -644,9 +644,10 @@ func (ctx *actorContext) stopAllChildren() {
 		return
 	}
 
-	ctx.extras.children.ForEach(func(_ int, pid *PID) {
-		ctx.Stop(pid)
-	})
+	var pids = ctx.extras.children.pids
+	for i := len(pids) - 1; i >= 0; i-- {
+		pids[i].sendSystemMessage(ctx.actorSystem, stopMessage)
+	}
 }
 
 func (ctx *actorContext) tryRestartOrTerminate() {


### PR DESCRIPTION
Stopping an actors children should happen in reverse of spawning order.

Example
----
Let's say actor `root` spawns the following actors in this order:

1. dbActor
2. reader
3. writer

Both reader and writer use the dbActor in order to save their state. If we poison `root`,  reader and writer won't be able to save their state. I suggest we inverse the order of stopping to make this common use-case feasible.

3. writer
2. reader
1. dbActor