### PR TITLE
use maps.Equal instead of reflect.DeepEqual

### DIFF
--- a/cluster/informer.go
+++ b/cluster/informer.go
@@ -7,7 +7,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"log/slog"
 	"math/rand"
-	"reflect"
+	"maps"
 	"time"
 
 	"github.com/asynkron/gofun/set"
@@ -211,7 +211,7 @@ func (inf *Informer) GetMemberStateDelta(targetMemberID string) *MemberStateDelt
 		}
 	}
 
-	hasState := reflect.DeepEqual(inf.committedOffsets, pendingOffsets)
+	hasState := maps.Equal(inf.committedOffsets, pendingOffsets)
 	memberState := &MemberStateDelta{
 		TargetMemberID: targetMemberID,
 		HasState:       hasState,


### PR DESCRIPTION
reflect causes a lot of memory allocations and uses more CPU time. maps.Equal does not cause any allocations and is about 80% faster

```
BenchmarkMapComparing/reflect.DeepEqual/10-8             1000000          1012 ns/op         320 B/op         30 allocs/op
BenchmarkMapComparing/maps.Equal/10-8                    7164884           170 ns/op           0 B/op          0 allocs/op
BenchmarkMapComparing/reflect.DeepEqual/20-8              629672          1899 ns/op         640 B/op         60 allocs/op
BenchmarkMapComparing/maps.Equal/20-8                    4098136           350 ns/op           0 B/op          0 allocs/op
BenchmarkMapComparing/reflect.DeepEqual/40-8              279854          3835 ns/op        1280 B/op        120 allocs/op
BenchmarkMapComparing/maps.Equal/40-8                    1950439           611 ns/op           0 B/op          0 allocs/op
BenchmarkMapComparing/reflect.DeepEqual/80-8              161636          7361 ns/op        2560 B/op        240 allocs/op
BenchmarkMapComparing/maps.Equal/80-8                    1000000          1157 ns/op           0 B/op          0 allocs/op
BenchmarkMapComparing/reflect.DeepEqual/100-8             128911          9429 ns/op        3200 B/op        300 allocs/op
BenchmarkMapComparing/maps.Equal/100-8                    840912          1421 ns/op           0 B/op          0 allocs/op
BenchmarkMapComparing/reflect.DeepEqual/200-8              65206         18791 ns/op        6400 B/op        600 allocs/op
BenchmarkMapComparing/maps.Equal/200-8                    424918          2888 ns/op           0 B/op          0 allocs/op
BenchmarkMapComparing/reflect.DeepEqual/400-8              33045         40529 ns/op       12800 B/op       1200 allocs/op
BenchmarkMapComparing/maps.Equal/400-8                    216856          5570 ns/op           0 B/op          0 allocs/op
```