### PR TITLE
Update examples/cluster-metrics

### DIFF
--- a/examples/cluster-metrics/client/main.go
+++ b/examples/cluster-metrics/client/main.go
@@ -82,7 +82,7 @@ func setupLogger(c *cluster.Cluster) {
 			log.Printf("Member Unavailable " + msg.Name())
 		case *cluster.MemberAvailableEvent:
 			log.Printf("Member Available " + msg.Name())
-		case cluster.ClusterTopology:
+		case *cluster.ClusterTopology:
 			log.Printf("Cluster Topology Poll")
 		}
 	})


### PR DESCRIPTION
cluster.ClusterTopology -> *cluster.ClusterTopology

This pull request includes a small change to the `examples/cluster-metrics/client/main.go` file. The change modifies the type of the `ClusterTopology` event case in the `setupLogger` function to use a pointer type.

* [`examples/cluster-metrics/client/main.go`](diffhunk://#diff-2f5f5486f9e37b66822c1dcfd6015ff4437ff973139bf0ba5775b46da96fa6e0L85-R85): Changed `case cluster.ClusterTopology` to `case *cluster.ClusterTopology` in the `setupLogger` function.