### PR TITLE
fix otel custom provider sample

### DIFF
--- a/examples/opentelemetry-custom-provider/main.go
+++ b/examples/opentelemetry-custom-provider/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"go.opentelemetry.io/otel"
 	"log"
 	"time"
 
@@ -46,6 +47,7 @@ func main() {
 		}
 	}()
 
+	otel.SetMeterProvider(meterProvider)
 	config := actor.Configure(actor.WithMetricProviders(meterProvider))
 	system := actor.NewActorSystemWithConfig(config)
 	props := actor.PropsFromProducer(func() actor.Actor {


### PR DESCRIPTION
expose metrics require calling `otel.SetMeterProvider(meterProvider)`

before (none calling `otel.SetMeterProvider(meterProvider)`)
```
1:01PM INF actor system started lib=Proto.Actor system=J8MjnjRbMnrMqwaRdKNLBg id=J8MjnjRbMnrMqwaRdKNLBg
{"Resource":[{"Key":"service.name","Value":{"Type":"STRING","Value":"test-service"}},{"Key":"service.version","Value":{"Type":"STRING","Value":"0.1.0"}},{"Key":"telemetry.sdk.language","Value":{"Type":"STRING","Value":"go"}},{"Key":"telemetry.sdk.name","Value":{"Type":"STRING","Value":"opentelemetry"}},{"Key":"telemetry.sdk.version","Value":{"Type":"STRING","Value":"1.22.0"}}],"ScopeMetrics":null}
```

after
```
1:01PM INF actor system started lib=Proto.Actor system=4zqzpEKUr5MvsLe7aHhdLg id=4zqzpEKUr5MvsLe7aHhdLg
Hello Stdout Exporter
{"Resource":[{"Key":"service.name","Value":{"Type":"STRING","Value":"test-service"}},{"Key":"service.version","Value":{"Type":"STRING","Value":"0.1.0"}},{"Key":"telemetry.sdk.language","Value":{"Type":"STRING","Value":"go"}},{"Key":"telemetry.sdk.name","Value":{"Type":"STRING","Value":"opentelemetry"}},{"Key":"telemetry.sdk.version","Value":{"Type":"STRING","Value":"1.22.0"}}],"ScopeMetrics":[{"Scope":{"Name":"protoactor","Version":"","SchemaURL":""},"Metrics":[{"Name":"protoactor_actor_message_receive_duration_seconds","Description":"Actor's messages received duration in seconds","Unit":"","Data":{"DataPoints":[{"Attributes":[{"Key":"actortype","Value":{"Type":"STRING","Value":"main.helloActor"}},{"Key":"address","Value":{"Type":"STRING","Value":"nonhost"}},{"Key":"messagetype","Value":{"Type":"STRING","Value":"*actor.Started"}}],"StartTime":"2025-01-03T13:01:49.9814+09:00","Time":"2025-01-03T13:01:52.979789+09:00","Count":1,"Bounds":[0,5,10,25,50,75,100,250,500,750,1000,2500,5000,7500,10000],"BucketCounts":[0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Min":{},"Max":{},"Sum":0.000004958},{"Attributes":[{"Key":"actortype","Value":{"Type":"STRING","Value":"main.helloActor"}},{"Key":"address","Value":{"Type":"STRING","Value":"nonhost"}},{"Key":"messagetype","Value":{"Type":"STRING","Value":"*main.hello"}}],"StartTime":"2025-01-03T13:01:49.9814+09:00","Time":"2025-01-03T13:01:52.979789+09:00","Count":1,"Bounds":[0,5,10,25,50,75,100,250,500,750,1000,2500,5000,7500,10000],"BucketCounts":[0,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"Min":{},"Max":{},"Sum":0.000003291}],"Temporality":"CumulativeTemporality"}},{"Name":"protoactor_actor_spawn_count","Description":"Number of actors spawn","Unit":"1","Data":{"DataPoints":[{"Attributes":[{"Key":"actortype","Value":{"Type":"STRING","Value":"main.helloActor"}},{"Key":"address","Value":{"Type":"STRING","Value":"nonhost"}}],"StartTime":"2025-01-03T13:01:49.981409+09:00","Time":"2025-01-03T13:01:52.979805+09:00","Value":1}],"Temporality":"CumulativeTemporality","IsMonotonic":true}}]}]}
```
