### PR TITLE
Removes race condition cluster get pid issue 1131

### DIFF
--- a/cluster/identitylookup/disthash/manager.go
+++ b/cluster/identitylookup/disthash/manager.go
@@ -1,12 +1,12 @@
 package disthash
 
 import (
-	"log/slog"
-	"time"
-
 	"github.com/asynkron/protoactor-go/actor"
 	clustering "github.com/asynkron/protoactor-go/cluster"
 	"github.com/asynkron/protoactor-go/eventstream"
+	"log/slog"
+	"sync"
+	"time"
 )
 
 const (
@@ -17,6 +17,7 @@ type Manager struct {
 	cluster        *clustering.Cluster
 	topologySub    *eventstream.Subscription
 	placementActor *actor.PID
+	rdvMutex       sync.RWMutex
 	rdv            *clustering.Rendezvous
 }
 
@@ -60,6 +61,9 @@ func (pm *Manager) PidOfActivatorActor(addr string) *actor.PID {
 }
 
 func (pm *Manager) onClusterTopology(tplg *clustering.ClusterTopology) {
+	pm.rdvMutex.Lock()
+	defer pm.rdvMutex.Unlock()
+
 	pm.cluster.Logger().Info("onClusterTopology", slog.Uint64("topology-hash", tplg.TopologyHash))
 
 	for _, m := range tplg.Members {
@@ -72,6 +76,9 @@ func (pm *Manager) onClusterTopology(tplg *clustering.ClusterTopology) {
 }
 
 func (pm *Manager) Get(identity *clustering.ClusterIdentity) *actor.PID {
+	pm.rdvMutex.RLock()
+	defer pm.rdvMutex.RUnlock()
+
 	ownerAddress := pm.rdv.GetByClusterIdentity(identity)
 
 	if ownerAddress == "" {

--- a/cluster/identitylookup/disthash/manager_test.go
+++ b/cluster/identitylookup/disthash/manager_test.go
@@ -1,0 +1,140 @@
+package disthash
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+	"github.com/asynkron/protoactor-go/cluster"
+	"github.com/asynkron/protoactor-go/cluster/clusterproviders/test"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestManagerConcurrentAccess verifies that concurrent access to the Manager
+// doesn't trigger race conditions
+func TestManagerConcurrentAccess(t *testing.T) {
+	system := actor.NewActorSystem()
+	provider := test.NewTestProvider(test.NewInMemAgent())
+	config := cluster.Configure("test-cluster", provider, disthash.New())
+	c := cluster.New(system, config)
+
+	manager := newPartitionManager(c)
+	manager.Start()
+	defer manager.Stop()
+
+	// Create a WaitGroup to synchronize goroutines
+	var wg sync.WaitGroup
+	iterations := 1000
+
+	// Simulate concurrent topology updates and lookups
+	wg.Add(2)
+
+	// Goroutine 1: Continuously update topology
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			members := []*cluster.Member{
+				{Id: "1", Host: "localhost", Port: 1},
+				{Id: "2", Host: "localhost", Port: 2},
+			}
+			topology := &cluster.ClusterTopology{
+				Members:      members,
+				TopologyHash: uint64(i),
+			}
+			manager.onClusterTopology(topology)
+		}
+	}()
+
+	// Goroutine 2: Continuously perform lookups
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			identity := &cluster.ClusterIdentity{
+				Identity: "test",
+				Kind:     "test",
+			}
+			_ = manager.Get(identity)
+		}
+	}()
+
+	// Wait with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Test completed successfully
+	case <-time.After(5 * time.Second):
+		t.Fatal("Test timed out")
+	}
+}
+
+// Integration test using ClusterFixture
+type DistHashManagerTestSuite struct {
+	suite.Suite
+	fixture *cluster_test_tool.BaseClusterFixture
+}
+
+func (suite *DistHashManagerTestSuite) SetupTest() {
+	suite.fixture = cluster_test_tool.NewBaseInMemoryClusterFixture(3)
+	suite.fixture.Initialize()
+}
+
+func (suite *DistHashManagerTestSuite) TearDownTest() {
+	suite.fixture.ShutDown()
+}
+
+func (suite *DistHashManagerTestSuite) TestConcurrentClusterOperations() {
+	// Get the clusters
+	clusters := suite.fixture.GetMembers()
+	assert.Equal(suite.T(), 3, len(clusters))
+
+	// Create multiple concurrent operations
+	var wg sync.WaitGroup
+	iterations := 100
+
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func(iteration int) {
+			defer wg.Done()
+
+			// Randomly select a cluster
+			cluster := clusters[iteration%len(clusters)]
+
+			// Perform a Get operation
+			identity := fmt.Sprintf("test-%d", iteration)
+			pid := cluster.Get(identity, "test-kind")
+
+			// Verify the operation completed without panicking
+			assert.NotPanics(suite.T(), func() {
+				if pid != nil {
+					// Optionally verify the PID properties
+					assert.NotEmpty(suite.T(), pid.Address)
+					assert.NotEmpty(suite.T(), pid.Id)
+				}
+			})
+		}(i)
+	}
+
+	// Wait with timeout
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Test completed successfully
+	case <-time.After(10 * time.Second):
+		suite.T().Fatal("Test timed out")
+	}
+}
+
+func TestDistHashManager(t *testing.T) {
+	suite.Run(t, new(DistHashManagerTestSuite))
+}

--- a/cluster/identitylookup/disthash/manager_test.go
+++ b/cluster/identitylookup/disthash/manager_test.go
@@ -1,22 +1,23 @@
 package disthash
 
 import (
-	"sync"
-	"testing"
-	"time"
-
+	"fmt"
 	"github.com/asynkron/protoactor-go/actor"
 	"github.com/asynkron/protoactor-go/cluster"
 	"github.com/asynkron/protoactor-go/cluster/clusterproviders/test"
+	"github.com/asynkron/protoactor-go/remote"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"sync"
+	"testing"
+	"time"
 )
 
-// TestManagerConcurrentAccess verifies that concurrent access to the Manager
-// doesn't trigger race conditions
 func TestManagerConcurrentAccess(t *testing.T) {
 	system := actor.NewActorSystem()
 	provider := test.NewTestProvider(test.NewInMemAgent())
-	config := cluster.Configure("test-cluster", provider, disthash.New())
+	lookup := New()
+	config := cluster.Configure("test-cluster", provider, lookup, remote.Configure("127.0.0.1", 0))
 	c := cluster.New(system, config)
 
 	manager := newPartitionManager(c)
@@ -73,25 +74,40 @@ func TestManagerConcurrentAccess(t *testing.T) {
 	}
 }
 
-// Integration test using ClusterFixture
+// Integration test suite
 type DistHashManagerTestSuite struct {
 	suite.Suite
-	fixture *cluster_test_tool.BaseClusterFixture
+	clusters []*cluster.Cluster
 }
 
 func (suite *DistHashManagerTestSuite) SetupTest() {
-	suite.fixture = cluster_test_tool.NewBaseInMemoryClusterFixture(3)
-	suite.fixture.Initialize()
+	// Create 3 cluster nodes for testing
+	suite.clusters = make([]*cluster.Cluster, 3)
+	inMemAgent := test.NewInMemAgent()
+
+	for i := 0; i < 3; i++ {
+		system := actor.NewActorSystem()
+		provider := test.NewTestProvider(inMemAgent)
+		config := cluster.Configure("test-cluster",
+			provider,
+			New(),
+			remote.Configure("localhost", 0),
+		)
+
+		c := cluster.New(system, config)
+		c.StartMember()
+		suite.clusters[i] = c
+	}
 }
 
 func (suite *DistHashManagerTestSuite) TearDownTest() {
-	suite.fixture.ShutDown()
+	for _, c := range suite.clusters {
+		c.Shutdown(true)
+	}
 }
 
 func (suite *DistHashManagerTestSuite) TestConcurrentClusterOperations() {
-	// Get the clusters
-	clusters := suite.fixture.GetMembers()
-	assert.Equal(suite.T(), 3, len(clusters))
+	assert.Equal(suite.T(), 3, len(suite.clusters))
 
 	// Create multiple concurrent operations
 	var wg sync.WaitGroup
@@ -103,7 +119,7 @@ func (suite *DistHashManagerTestSuite) TestConcurrentClusterOperations() {
 			defer wg.Done()
 
 			// Randomly select a cluster
-			cluster := clusters[iteration%len(clusters)]
+			cluster := suite.clusters[iteration%len(suite.clusters)]
 
 			// Perform a Get operation
 			identity := fmt.Sprintf("test-%d", iteration)


### PR DESCRIPTION
I read the contributing.md and followed the steps
Added tests for manager in disthash
TestManagerConcurrentAccess simulates the race condition by spawning two goroutines - one updates topology continuously while another performs identity lookups, verifying no data races occur under concurrent read/write operations to the rdv field.
TestConcurrentClusterOperations creates a 3-node cluster and performs 100 concurrent identity lookups across different nodes

The tests reveal there is a lot of different data races but no longer in onClusterTopology and get. 