### PR TITLE
Ignore both PUT and DELETE events while etcd nodes changing

### DIFF
--- a/cluster/clusterproviders/etcd/etcd_provider.go
+++ b/cluster/clusterproviders/etcd/etcd_provider.go
@@ -259,6 +259,10 @@ func (p *Provider) handleWatchResponse(resp clientv3.WatchResponse) map[string]*
 			if !ok {
 				continue
 			}
+			if p.self.Equal(node) {
+				p.cluster.Logger().Debug("Skip self.", slog.String("key", key))
+				continue
+			}
 			p.cluster.Logger().Debug("Delete member.", slog.String("key", key))
 			cloned := *node
 			cloned.SetAlive(false)


### PR DESCRIPTION
This pull request includes a change to the `handleWatchResponse` function in the `etcd_provider.go` file to improve the handling of self-node events. The most important change is the addition of a condition to skip processing events related to the node itself.

Changes to self-node event handling:

* [`cluster/clusterproviders/etcd/etcd_provider.go`](diffhunk://#diff-0f77da47461de11b75c73f5b268bc9c9b0637cfbf74ca472d0ef8545ad056a1aR262-R265): Added a condition in the `handleWatchResponse` function to skip processing events related to the node itself and log a debug message when this occurs.