### PR TITLE
Ensure DeadLetterResponse carries target PID

### DIFF
--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -30,9 +30,9 @@ func NewDeadLetter(actorSystem *ActorSystem) *deadLetterProcess {
 	_ = actorSystem.EventStream.Subscribe(func(msg interface{}) {
 		if deadLetter, ok := msg.(*DeadLetterEvent); ok {
 
-			// send back a response instead of timeout.
+			// send back a response instead of timeout, including the target PID.
 			if deadLetter.Sender != nil {
-				actorSystem.Root.Send(deadLetter.Sender, &DeadLetterResponse{})
+				actorSystem.Root.Send(deadLetter.Sender, &DeadLetterResponse{Target: deadLetter.PID})
 			}
 
 			// bail out if sender is set and deadletter request logging is false

--- a/actor/deadletter_response_test.go
+++ b/actor/deadletter_response_test.go
@@ -1,0 +1,41 @@
+package actor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRequestToStoppedActorReturnsDeadLetterError(t *testing.T) {
+	pid := rootContext.Spawn(PropsFromProducer(NewBlackHoleActor))
+	_ = rootContext.StopFuture(pid).Wait()
+
+	future := rootContext.RequestFuture(pid, "hello", testTimeout)
+	res, err := future.Result()
+	assert.Nil(t, res)
+	assert.Equal(t, ErrDeadLetter, err)
+}
+
+func TestDeadLetterResponseContainsTargetPID(t *testing.T) {
+	pid := rootContext.Spawn(PropsFromProducer(NewBlackHoleActor))
+	_ = rootContext.StopFuture(pid).Wait()
+
+	ch := make(chan *DeadLetterResponse, 1)
+	sender := rootContext.Spawn(PropsFromFunc(func(ctx Context) {
+		if msg, ok := ctx.Message().(*DeadLetterResponse); ok {
+			ch <- msg
+		}
+	}))
+
+	rootContext.RequestWithCustomSender(pid, "hello", sender)
+
+	select {
+	case msg := <-ch:
+		assert.Equal(t, pid, msg.Target)
+	case <-time.After(testTimeout):
+		t.Fatalf("did not receive dead letter response")
+	}
+
+	rootContext.Stop(sender)
+}


### PR DESCRIPTION
## Summary
- include target PID in dead-letter responses
- test dead-letter responses and request error when sending to stopped actors

## Testing
- `go test ./actor`


------
https://chatgpt.com/codex/tasks/task_e_689a1e8cc0408328980e73103fa8cfb3