### PR TITLE
feat(actor): port captured context

### DIFF
--- a/actor/actor_context.go
+++ b/actor/actor_context.go
@@ -281,6 +281,17 @@ func (ctx *actorContext) ReenterAfter(f *Future, cont func(res interface{}, err 
 	})
 }
 
+func (ctx *actorContext) Capture() *CapturedContext {
+	return &CapturedContext{
+		MessageEnvelope: WrapEnvelope(ctx.messageOrEnvelope),
+		Context:         ctx,
+	}
+}
+
+func (ctx *actorContext) Apply(captured *CapturedContext) {
+	ctx.messageOrEnvelope = captured.MessageEnvelope
+}
+
 //
 // Interface: sender
 //

--- a/actor/captured_context.go
+++ b/actor/captured_context.go
@@ -1,0 +1,20 @@
+package actor
+
+// CapturedContext holds a message envelope along with the context it was captured from.
+type CapturedContext struct {
+	MessageEnvelope *MessageEnvelope
+	Context         Context
+}
+
+// Receive reprocesses the captured message on the captured context.
+// It captures the current context state before processing and restores it afterwards.
+func (cc *CapturedContext) Receive() {
+	current := cc.Context.Capture()
+	cc.Context.Receive(cc.MessageEnvelope)
+	current.Apply()
+}
+
+// Apply restores the stored message to the actor context so it can be re-processed by the actor.
+func (cc *CapturedContext) Apply() {
+	cc.Context.Apply(cc)
+}

--- a/actor/common_test.go
+++ b/actor/common_test.go
@@ -106,6 +106,15 @@ func (m *mockContext) ReenterAfter(f *Future, cont func(res interface{}, err err
 	m.Called(f, cont)
 }
 
+func (m *mockContext) Capture() *CapturedContext {
+	args := m.Called()
+	return args.Get(0).(*CapturedContext)
+}
+
+func (m *mockContext) Apply(captured *CapturedContext) {
+	m.Called(captured)
+}
+
 //
 // Interface: SenderContext
 //

--- a/actor/context.go
+++ b/actor/context.go
@@ -94,6 +94,13 @@ type basePart interface {
 	Forward(pid *PID)
 
 	ReenterAfter(f *Future, continuation func(res interface{}, err error))
+
+	// Capture captures the current MessageEnvelope for the context.
+	// Use the returned CapturedContext to reprocess messages later.
+	Capture() *CapturedContext
+
+	// Apply overwrites the context current state with the state from the captured context.
+	Apply(captured *CapturedContext)
 }
 
 type messagePart interface {

--- a/actor/stashing_test.go
+++ b/actor/stashing_test.go
@@ -1,0 +1,138 @@
+package actor
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type stashingActor struct {
+	captured        *CapturedContext
+	stashed         bool
+	processed       *[]string
+	self            *PID
+	sender          *PID
+	selfPreserved   bool
+	senderPreserved bool
+}
+
+func newStashingActor(processed *[]string) *stashingActor {
+	return &stashingActor{processed: processed}
+}
+
+func (a *stashingActor) Receive(ctx Context) {
+	switch msg := ctx.Message().(type) {
+	case string:
+		if msg == "unstash" {
+			if a.captured != nil {
+				a.captured.Receive()
+				a.captured = nil
+			}
+			return
+		}
+
+		if !a.stashed {
+			a.self = ctx.Self()
+			a.sender = ctx.Sender()
+			a.captured = ctx.Capture()
+			a.stashed = true
+			return
+		}
+
+		if msg == "first" {
+			a.selfPreserved = a.self == ctx.Self()
+			a.senderPreserved = a.sender == ctx.Sender()
+		}
+
+		*a.processed = append(*a.processed, msg)
+		ctx.Respond(msg)
+	}
+}
+
+type applyActor struct {
+	captured         *CapturedContext
+	observed         *[]string
+	contextCorrupted bool
+}
+
+func newApplyActor(observed *[]string) *applyActor {
+	return &applyActor{observed: observed}
+}
+
+func (a *applyActor) Receive(ctx Context) {
+	switch msg := ctx.Message().(type) {
+	case string:
+		switch msg {
+		case "stash":
+			a.captured = ctx.Capture()
+		case "apply":
+			current := ctx.Capture()
+			if a.captured != nil {
+				a.captured.Apply()
+			}
+			*a.observed = append(*a.observed, ctx.Message().(string))
+			current.Apply()
+			if ctx.Message().(string) != current.MessageEnvelope.Message {
+				a.contextCorrupted = true
+			}
+			*a.observed = append(*a.observed, ctx.Message().(string))
+			ctx.Respond("ok")
+		}
+	}
+}
+
+// Test that a captured message can be processed later and retains context information.
+func TestCapturedContext_ReplayedMessageIsProcessedOnce(t *testing.T) {
+	t.Parallel()
+
+	processed := make([]string, 0, 2)
+	var act *stashingActor
+	props := PropsFromProducer(func() Actor {
+		act = newStashingActor(&processed)
+		return act
+	})
+	pid := rootContext.Spawn(props)
+	defer rootContext.Stop(pid)
+
+	f1 := rootContext.RequestFuture(pid, "first", time.Second)
+
+	// trigger processing of the stashed message
+	rootContext.Send(pid, "unstash")
+
+	f2 := rootContext.RequestFuture(pid, "second", time.Second)
+
+	r1, err1 := f1.Result()
+	assert.NoError(t, err1)
+	assert.Equal(t, "first", r1.(string))
+
+	r2, err2 := f2.Result()
+	assert.NoError(t, err2)
+	assert.Equal(t, "second", r2.(string))
+
+	assert.Equal(t, []string{"first", "second"}, processed)
+	assert.True(t, act.selfPreserved)
+	assert.True(t, act.senderPreserved)
+}
+
+// Test that Apply restores a captured message without corrupting current context.
+func TestCapturedContext_ApplyRestoresMessage(t *testing.T) {
+	t.Parallel()
+
+	observed := make([]string, 0, 2)
+	var act *applyActor
+	props := PropsFromProducer(func() Actor {
+		act = newApplyActor(&observed)
+		return act
+	})
+	pid := rootContext.Spawn(props)
+	defer rootContext.Stop(pid)
+
+	rootContext.Send(pid, "stash")
+	f := rootContext.RequestFuture(pid, "apply", time.Second)
+	_, err := f.Result()
+	assert.NoError(t, err)
+
+	assert.Equal(t, []string{"stash", "apply"}, observed)
+	assert.False(t, act.contextCorrupted)
+}

--- a/router/common_test.go
+++ b/router/common_test.go
@@ -110,6 +110,15 @@ func (m *mockContext) ReenterAfter(f *actor.Future, cont func(res interface{}, e
 	m.Called(f, cont)
 }
 
+func (m *mockContext) Capture() *actor.CapturedContext {
+	args := m.Called()
+	return args.Get(0).(*actor.CapturedContext)
+}
+
+func (m *mockContext) Apply(captured *actor.CapturedContext) {
+	m.Called(captured)
+}
+
 //
 // Interface: SenderContext
 //


### PR DESCRIPTION
## Summary
- add CapturedContext for replaying stored message envelopes
- extend Context with Capture and Apply helpers
- verify captured messages can be replayed and applied without corrupting context

## Testing
- `go test ./actor -run TestCapturedContext -count=1`
- `go test ./actor -count=1`
- `go test ./router -count=1` *(fails: TestConcurrency timed out)*


------
https://chatgpt.com/codex/tasks/task_e_689a1e85f354832886b5b38405ef7182