### PR TITLE
Use unwrapped message type in dead letter metrics

### DIFF
--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -74,6 +74,9 @@ type DeadLetterEvent struct {
 }
 
 func (dp *deadLetterProcess) SendUserMessage(pid *PID, message interface{}) {
+	// unwrap the incoming envelope to access the actual message and sender
+	_, msg, sender := UnwrapEnvelope(message)
+
 	if dp.actorSystem.Config.MetricsEnabled {
 		metricsSystem, ok := dp.actorSystem.Extensions.Get(extensionId).(*Metrics)
 		if ok && metricsSystem.Enabled() {
@@ -81,14 +84,15 @@ func (dp *deadLetterProcess) SendUserMessage(pid *PID, message interface{}) {
 			if instruments := metricsSystem.metrics.Get(metrics.InternalActorMetrics); instruments != nil {
 				labels := []attribute.KeyValue{
 					attribute.String("address", dp.actorSystem.Address()),
-					attribute.String("messagetype", strings.Replace(fmt.Sprintf("%T", message), "*", "", 1)),
+					attribute.String("id", dp.actorSystem.ID),
+					attribute.String("messagetype", strings.Replace(fmt.Sprintf("%T", msg), "*", "", 1)),
 				}
 
 				instruments.DeadLetterCount.Add(ctx, 1, metric.WithAttributes(labels...))
 			}
 		}
 	}
-	_, msg, sender := UnwrapEnvelope(message)
+
 	dp.actorSystem.EventStream.Publish(&DeadLetterEvent{
 		PID:     pid,
 		Message: msg,


### PR DESCRIPTION
## Summary
- unwrap dead letters before constructing metric labels
- include actor system ID in dead letter metrics

## Testing
- `go test ./actor`
- `go test ./...` *(fails: Failed to register service to consul)*

------
https://chatgpt.com/codex/tasks/task_e_689b744968788328b5c6121014623296