### PR TITLE
Add actor system ID to metric labels

### DIFF
--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -81,6 +81,7 @@ func (dp *deadLetterProcess) SendUserMessage(pid *PID, message interface{}) {
 			if instruments := metricsSystem.metrics.Get(metrics.InternalActorMetrics); instruments != nil {
 				labels := []attribute.KeyValue{
 					attribute.String("address", dp.actorSystem.Address()),
+					attribute.String("id", dp.actorSystem.ID),
 					attribute.String("messagetype", strings.Replace(fmt.Sprintf("%T", message), "*", "", 1)),
 				}
 

--- a/actor/future.go
+++ b/actor/future.go
@@ -37,6 +37,7 @@ func NewFuture(actorSystem *ActorSystem, d time.Duration) *Future {
 				ctx := context.Background()
 				labels := []attribute.KeyValue{
 					attribute.String("address", ref.actorSystem.Address()),
+					attribute.String("id", actorSystem.ID),
 				}
 
 				instruments.FuturesStartedCount.Add(ctx, 1, metric.WithAttributes(labels...))
@@ -179,6 +180,7 @@ func (ref *futureProcess) instrument() {
 			ctx := context.Background()
 			labels := []attribute.KeyValue{
 				attribute.String("address", ref.actorSystem.Address()),
+				attribute.String("id", ref.actorSystem.ID),
 			}
 
 			instruments := sysMetrics.metrics.Get(metrics.InternalActorMetrics)

--- a/actor/metrics.go
+++ b/actor/metrics.go
@@ -45,6 +45,7 @@ func NewMetrics(system *ActorSystem, provider metric.MeterProvider) *Metrics {
 func (m *Metrics) CommonLabels(ctx Context) []attribute.KeyValue {
 	labels := []attribute.KeyValue{
 		attribute.String("address", ctx.ActorSystem().Address()),
+		attribute.String("id", ctx.ActorSystem().ID),
 		attribute.String("actortype", strings.Replace(fmt.Sprintf("%T", ctx.Actor()), "*", "", 1)),
 	}
 


### PR DESCRIPTION
## Summary
- tag actor metrics with actor system IDs via CommonLabels
- include system ID in future and dead-letter metric labels

## Testing
- `go test ./actor -run TestNonExistent`

------
https://chatgpt.com/codex/tasks/task_e_689b7429252483289fde0737d2c36714