### PR TITLE
metrics: count only timeout futures

### DIFF
--- a/actor/future.go
+++ b/actor/future.go
@@ -183,10 +183,14 @@ func (ref *futureProcess) instrument() {
 
 			instruments := sysMetrics.metrics.Get(metrics.InternalActorMetrics)
 			if instruments != nil {
-				if ref.err == nil {
+				switch {
+				case ref.err == nil:
+					// The future completed successfully.
 					instruments.FuturesCompletedCount.Add(ctx, 1, metric.WithAttributes(labels...))
-				} else {
+				case ref.err == ErrTimeout:
+					// Only count actual timeouts as timed out futures.
 					instruments.FuturesTimedOutCount.Add(ctx, 1, metric.WithAttributes(labels...))
+					// Other errors are not counted toward timeout metrics.
 				}
 			}
 		}

--- a/actor/future_metrics_test.go
+++ b/actor/future_metrics_test.go
@@ -1,0 +1,67 @@
+package actor
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+// TestFutureMetrics_NoTimeoutCount ensures non-timeout errors are not counted as timeouts.
+func TestFutureMetrics_NoTimeoutCount(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+
+	system := NewActorSystemWithConfig(&Config{
+		MetricsProvider: provider,
+		MetricsEnabled:  true,
+		LoggerFactory: func(_ *ActorSystem) *slog.Logger {
+			return slog.New(slog.NewTextHandler(io.Discard, nil))
+		},
+	})
+	defer system.Shutdown()
+
+	// Successful future; should increment FuturesCompletedCount.
+	success := NewFuture(system, time.Second)
+	system.Root.Send(success.PID(), "ok")
+	_, _ = success.Result()
+
+	// Future that resolves with a non-timeout error (dead letter).
+	failed := NewFuture(system, time.Second)
+	system.Root.Send(failed.PID(), &DeadLetterResponse{})
+	_, _ = failed.Result()
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	var completed, timedout int64
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "protoactor_future_completed_count":
+				if data, ok := m.Data.(metricdata.Sum[int64]); ok && len(data.DataPoints) > 0 {
+					completed = data.DataPoints[0].Value
+				}
+			case "protoactor_future_timedout_count":
+				if data, ok := m.Data.(metricdata.Sum[int64]); ok && len(data.DataPoints) > 0 {
+					timedout = data.DataPoints[0].Value
+				}
+			}
+		}
+	}
+
+	if completed != 1 {
+		t.Fatalf("expected 1 completed future, got %d", completed)
+	}
+	if timedout != 0 {
+		t.Fatalf("expected 0 timed out futures, got %d", timedout)
+	}
+}


### PR DESCRIPTION
## Summary
- stop counting all future errors as timeouts
- add regression test ensuring only true timeouts are counted

## Testing
- `go test ./actor -count=1`
- `go test ./...` *(fails: Get "http://127.0.0.1:8500/v1/health/service/mycluster5": dial tcp 127.0.0.1:8500: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689b7436e5b88328bfccb5fe9e374646