### PR TITLE
Remove pointer prefix from actor message metric label

### DIFF
--- a/actor/actor_context.go
+++ b/actor/actor_context.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -507,10 +508,9 @@ func (ctx *actorContext) InvokeUserMessage(md interface{}) {
 			ctx.processMessage(md)
 			delta := time.Since(t)
 
-
 			labels := append(
 				systemMetrics.CommonLabels(ctx),
-				attribute.String("messagetype", fmt.Sprintf("%T", md)),
+				attribute.String("messagetype", strings.Replace(fmt.Sprintf("%T", md), "*", "", 1)),
 			)
 			instruments.ActorMessageReceiveDuration.Record(_ctx, delta.Seconds(), metric.WithAttributes(labels...))
 		} else {


### PR DESCRIPTION
## Summary
- avoid pointer prefix when recording message type in metrics

## Testing
- `go test ./actor`


------
https://chatgpt.com/codex/tasks/task_e_689b7752468c8328a96b8d83f6773398