### PR TITLE
fix: configure global meter provider in metrics

### DIFF
--- a/actor/metrics.go
+++ b/actor/metrics.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/asynkron/protoactor-go/extensions"
 	"github.com/asynkron/protoactor-go/metrics"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -30,10 +31,18 @@ func (m *Metrics) ExtensionID() extensions.ExtensionID {
 	return extensionId
 }
 
+// NewMetrics initializes metrics collection for the given actor system using the
+// supplied OpenTelemetry MeterProvider. It also sets the global MeterProvider via
+// otel.SetMeterProvider, which changes process-wide state so other packages will
+// use the same provider.
 func NewMetrics(system *ActorSystem, provider metric.MeterProvider) *Metrics {
 	if provider == nil || !system.Config.MetricsEnabled {
 		return &Metrics{}
 	}
+
+	// Configure the global OpenTelemetry MeterProvider so that subsequent metric
+	// instruments use the supplied provider.
+	otel.SetMeterProvider(provider)
 
 	return &Metrics{
 		metrics:     metrics.NewProtoMetrics(system.Logger()),

--- a/actor/metrics_test.go
+++ b/actor/metrics_test.go
@@ -67,3 +67,25 @@ func TestActorMetrics(t *testing.T) {
 		t.Fatalf("missing metrics spawn:%v mailbox:%v duration:%v", foundSpawn, foundMailbox, foundDuration)
 	}
 }
+
+// TestNewMetricsSetsGlobalProvider verifies that NewMetrics installs the supplied
+// meter provider as the process-wide default. Because this mutates global
+// state, the previous provider is restored after the test completes.
+func TestNewMetricsSetsGlobalProvider(t *testing.T) {
+	// Save and restore the existing provider so the global state does not
+	// leak to other tests.
+	prev := otel.GetMeterProvider()
+	t.Cleanup(func() { otel.SetMeterProvider(prev) })
+
+	cfg := NewConfig()
+	cfg.MetricsEnabled = true
+	system := NewActorSystemWithConfig(cfg)
+	defer system.Shutdown()
+
+	provider := sdkmetric.NewMeterProvider()
+	NewMetrics(system, provider)
+
+	if got := otel.GetMeterProvider(); got != provider {
+		t.Fatalf("expected global meter provider to change")
+	}
+}


### PR DESCRIPTION
## Summary
- set the provided OpenTelemetry meter provider as the global provider when metrics are initialized
- document that NewMetrics sets the global meter provider and alters process-wide state
- add a unit test verifying NewMetrics updates the global meter provider and restores the previous provider after the test

## Testing
- `go test ./actor -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689b7754bc448328bfffcf07a9397937