### PR TITLE
feat(remote): add metrics instrumentation

### DIFF
--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	"github.com/asynkron/protoactor-go/actor"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	context2 "golang.org/x/net/context"
 )
 
 // Register a known actor props by name
@@ -112,6 +115,12 @@ func (a *activator) Receive(context actor.Context) {
 		pid, err := context.SpawnNamed(props, "Remote$"+name)
 
 		if err == nil {
+			if a.remote.metricsEnabled {
+				_ctx := context2.Background()
+				attrs := append(a.remote.commonLabels(), attribute.String("kind", msg.Kind))
+				a.remote.metrics.RemoteActorSpawnCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
+			}
+
 			response := &ActorPidResponse{Pid: pid}
 			context.Respond(response)
 		} else if err == actor.ErrNameExists {

--- a/remote/endpoint_reader.go
+++ b/remote/endpoint_reader.go
@@ -8,6 +8,8 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/asynkron/protoactor-go/actor"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/net/context"
 )
 
@@ -135,7 +137,14 @@ func (s *endpointReader) onMessageBatch(m *MessageBatch) error {
 			return errors.New("unknown target")
 		}
 
-		message, err := Deserialize(data, m.TypeNames[envelope.TypeId], envelope.SerializerId)
+		typeName := m.TypeNames[envelope.TypeId]
+		if s.remote.metricsEnabled {
+			_ctx := context.Background()
+			attrs := append(s.remote.commonLabels(), attribute.String("messagetype", typeName))
+			s.remote.metrics.RemoteDeserializedMessageCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
+		}
+
+		message, err := Deserialize(data, typeName, envelope.SerializerId)
 		if err != nil {
 			s.remote.Logger().Error("EndpointReader failed to deserialize", slog.Any("error", err))
 			return err

--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/asynkron/protoactor-go/actor"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
@@ -151,6 +153,13 @@ func (state *endpointWriter) initializeInternal() error {
 
 	connected := &EndpointConnectedEvent{Address: state.address}
 	state.remote.actorSystem.EventStream.Publish(connected)
+
+	if state.remote.metricsEnabled {
+		_ctx := context.Background()
+		attrs := append(state.remote.commonLabels(), attribute.String("destinationaddress", state.address))
+		state.remote.metrics.RemoteEndpointConnectedCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
+	}
+
 	return nil
 }
 
@@ -219,6 +228,13 @@ func (state *endpointWriter) sendEnvelopes(msg []interface{}, ctx actor.Context)
 			state.remote.Logger().Error("EndpointWriter failed to serialize message", slog.String("address", state.address), slog.Any("error", err), slog.Any("message", message))
 			continue
 		}
+
+		if state.remote.metricsEnabled {
+			_ctx := context.Background()
+			attrs := append(state.remote.commonLabels(), attribute.String("messagetype", typeName))
+			state.remote.metrics.RemoteSerializedMessageCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
+		}
+
 		typeID, typeNamesArr = addToLookup(typeNames, typeName, typeNamesArr)
 		targetID, targetNamesArr = addToTargetLookup(targetNames, rd.target, targetNamesArr)
 		targetRequestID := rd.target.RequestId
@@ -245,6 +261,7 @@ func (state *endpointWriter) sendEnvelopes(msg []interface{}, ctx actor.Context)
 		return
 	}
 
+	start := time.Now()
 	err := state.stream.Send(&RemoteMessage{
 		MessageType: &RemoteMessage_MessageBatch{
 			MessageBatch: &MessageBatch{
@@ -255,6 +272,13 @@ func (state *endpointWriter) sendEnvelopes(msg []interface{}, ctx actor.Context)
 			},
 		},
 	})
+
+	if state.remote.metricsEnabled {
+		_ctx := context.Background()
+		attrs := append(state.remote.commonLabels(), attribute.String("destinationaddress", state.address))
+		state.remote.metrics.RemoteWriteDuration.Record(_ctx, time.Since(start).Seconds(), metric.WithAttributes(attrs...))
+	}
+
 	if err != nil {
 		ctx.Stash()
 		state.remote.Logger().Debug("gRPC Failed to send", slog.String("address", state.address), slog.Any("error", err))
@@ -332,6 +356,11 @@ func (state *endpointWriter) Receive(ctx actor.Context) {
 
 func (state *endpointWriter) closeClientConn() {
 	state.remote.Logger().Info("EndpointWriter closing client connection", slog.String("address", state.address))
+
+	if state.remote.metricsEnabled {
+		_ctx := context.Background()
+		state.remote.metrics.RemoteEndpointDisconnectedCount.Add(_ctx, 1, metric.WithAttributes(state.remote.commonLabels()...))
+	}
 	if state.stream != nil {
 		err := state.stream.CloseSend()
 		if err != nil {

--- a/remote/metrics/remote_metrics_test.go
+++ b/remote/metrics/remote_metrics_test.go
@@ -12,4 +12,8 @@ func TestNewRemoteMetrics(t *testing.T) {
 	if m == nil {
 		t.Fatalf("expected metrics instance")
 	}
+	if m.RemoteWriteDuration == nil || m.RemoteActorSpawnCount == nil || m.RemoteSerializedMessageCount == nil ||
+		m.RemoteDeserializedMessageCount == nil || m.RemoteEndpointConnectedCount == nil || m.RemoteEndpointDisconnectedCount == nil {
+		t.Fatalf("expected all metric instruments to be initialized")
+	}
 }

--- a/remote/server.go
+++ b/remote/server.go
@@ -10,6 +10,8 @@ import (
 	"github.com/asynkron/protoactor-go/extensions"
 
 	"github.com/asynkron/protoactor-go/actor"
+	remotemetrics "github.com/asynkron/protoactor-go/remote/metrics"
+	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
 )
@@ -17,14 +19,16 @@ import (
 var extensionId = extensions.NextExtensionID()
 
 type Remote struct {
-	actorSystem  *actor.ActorSystem
-	s            *grpc.Server
-	edpReader    *endpointReader
-	edpManager   *endpointManager
-	config       *Config
-	kinds        map[string]*actor.Props
-	activatorPid *actor.PID
-	blocklist    *BlockList
+	actorSystem    *actor.ActorSystem
+	s              *grpc.Server
+	edpReader      *endpointReader
+	edpManager     *endpointManager
+	config         *Config
+	kinds          map[string]*actor.Props
+	activatorPid   *actor.PID
+	blocklist      *BlockList
+	metrics        *remotemetrics.RemoteMetrics
+	metricsEnabled bool
 }
 
 func NewRemote(actorSystem *actor.ActorSystem, config *Config) *Remote {
@@ -36,6 +40,11 @@ func NewRemote(actorSystem *actor.ActorSystem, config *Config) *Remote {
 	}
 	for k, v := range config.Kinds {
 		r.kinds[k] = v
+	}
+
+	if actorSystem.Config.MetricsEnabled {
+		r.metrics = remotemetrics.NewRemoteMetrics(actorSystem.Logger())
+		r.metricsEnabled = true
 	}
 
 	actorSystem.Extensions.Register(r)
@@ -55,6 +64,13 @@ func (r *Remote) ExtensionID() extensions.ExtensionID {
 }
 
 func (r *Remote) BlockList() *BlockList { return r.blocklist }
+
+func (r *Remote) commonLabels() []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("id", r.actorSystem.ID),
+		attribute.String("address", r.actorSystem.Address()),
+	}
+}
 
 // Start the remote server
 func (r *Remote) Start() {

--- a/remote/tests/remote_metrics_test.go
+++ b/remote/tests/remote_metrics_test.go
@@ -1,0 +1,143 @@
+package remote_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+	remote "github.com/asynkron/protoactor-go/remote"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func newSystem(provider *sdkmetric.MeterProvider) *actor.ActorSystem {
+	cfg := actor.NewConfig()
+	cfg.MetricsProvider = provider
+	cfg.MetricsEnabled = true
+	cfg.LoggerFactory = func(_ *actor.ActorSystem) *slog.Logger {
+		return slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return actor.NewActorSystemWithConfig(cfg)
+}
+
+func TestRemoteMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+
+	system1 := newSystem(provider)
+	remote1 := remote.NewRemote(system1, remote.Configure("127.0.0.1", 0))
+	remote1.Start()
+	defer system1.Shutdown()
+
+	system2 := newSystem(provider)
+	remote2 := remote.NewRemote(system2, remote.Configure("127.0.0.1", 0))
+	remote2.Register("echo", actor.PropsFromFunc(func(ctx actor.Context) {
+		if _, ok := ctx.Message().(*remote.ActorPidRequest); ok {
+			// no-op
+		}
+	}))
+	remote2.Start()
+	defer system2.Shutdown()
+
+	resp, err := remote1.Spawn(system2.Address(), "echo", time.Second)
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if resp.Pid == nil {
+		t.Fatalf("expected pid from spawn")
+	}
+
+	system1.Root.Send(resp.Pid, &remote.ActorPidRequest{})
+	time.Sleep(100 * time.Millisecond)
+
+	remote1.Shutdown(true)
+	remote2.Shutdown(true)
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	assertSumMetric(t, rm, "protoremote_endpoint_connected_count", map[string]string{
+		"id":                 system1.ID,
+		"address":            system1.Address(),
+		"destinationaddress": system2.Address(),
+	})
+	assertSumMetric(t, rm, "protoremote_endpoint_disconnected_count", map[string]string{
+		"id":      system1.ID,
+		"address": system1.Address(),
+	})
+	assertSumMetric(t, rm, "protoremote_message_serialize_count", map[string]string{
+		"id":          system1.ID,
+		"address":     system1.Address(),
+		"messagetype": "remote.ActorPidRequest",
+	})
+	assertSumMetric(t, rm, "protoremote_message_deserialize_count", map[string]string{
+		"id":          system2.ID,
+		"address":     system2.Address(),
+		"messagetype": "remote.ActorPidRequest",
+	})
+	assertSumMetric(t, rm, "protoremote_spawn_count", map[string]string{
+		"id":      system2.ID,
+		"address": system2.Address(),
+		"kind":    "echo",
+	})
+	assertHistogramMetric(t, rm, "protoremote_write_duration", map[string]string{
+		"id":                 system1.ID,
+		"address":            system1.Address(),
+		"destinationaddress": system2.Address(),
+	})
+}
+
+func hasAttributes(set attribute.Set, attrs map[string]string) bool {
+	for k, v := range attrs {
+		if val, ok := set.Value(attribute.Key(k)); !ok || val.AsString() != v {
+			return false
+		}
+	}
+	return true
+}
+
+func assertSumMetric(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string) {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			if data, ok := m.Data.(metricdata.Sum[int64]); ok {
+				for _, dp := range data.DataPoints {
+					if hasAttributes(dp.Attributes, attrs) && dp.Value > 0 {
+						return
+					}
+				}
+			}
+		}
+	}
+	t.Fatalf("metric %s with attrs %v not found", name, attrs)
+}
+
+func assertHistogramMetric(t *testing.T, rm metricdata.ResourceMetrics, name string, attrs map[string]string) {
+	t.Helper()
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			if data, ok := m.Data.(metricdata.Histogram[float64]); ok {
+				for _, dp := range data.DataPoints {
+					if hasAttributes(dp.Attributes, attrs) && dp.Count > 0 {
+						return
+					}
+				}
+			}
+		}
+	}
+	t.Fatalf("metric %s with attrs %v not found", name, attrs)
+}


### PR DESCRIPTION
## Summary
- add metrics initialization and helpers to Remote
- record remote metrics for serialization, deserialization, actor spawns, connection events, and write durations

## Testing
- `go test ./remote/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689b8356ac5c832882eed28c2d069418