### PR TITLE
feat(cluster): add opentelemetry metrics

### DIFF
--- a/actor/actor_context.go
+++ b/actor/actor_context.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -510,7 +509,7 @@ func (ctx *actorContext) InvokeUserMessage(md interface{}) {
 
 			labels := append(
 				systemMetrics.CommonLabels(ctx),
-				attribute.String("messagetype", strings.Replace(fmt.Sprintf("%T", md), "*", "", 1)),
+				attribute.String("messagetype", MessageName(md)),
 			)
 			instruments.ActorMessageReceiveDuration.Record(_ctx, delta.Seconds(), metric.WithAttributes(labels...))
 		} else {

--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -2,9 +2,7 @@ package actor
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/asynkron/protoactor-go/metrics"
 	"go.opentelemetry.io/otel/attribute"
@@ -85,7 +83,7 @@ func (dp *deadLetterProcess) SendUserMessage(pid *PID, message interface{}) {
 				labels := []attribute.KeyValue{
 					attribute.String("address", dp.actorSystem.Address()),
 					attribute.String("id", dp.actorSystem.ID),
-					attribute.String("messagetype", strings.Replace(fmt.Sprintf("%T", msg), "*", "", 1)),
+					attribute.String("messagetype", MessageName(msg)),
 				}
 
 				instruments.DeadLetterCount.Add(ctx, 1, metric.WithAttributes(labels...))

--- a/actor/messagetype.go
+++ b/actor/messagetype.go
@@ -1,0 +1,27 @@
+package actor
+
+import "reflect"
+
+// MessageType returns the full type name of the given message, including any
+// pointer prefix. It is typically used in logging where the exact Go type is
+// desired. If msg is nil, "<nil>" is returned.
+func MessageType(msg interface{}) string {
+	if msg == nil {
+		return "<nil>"
+	}
+	return reflect.TypeOf(msg).String()
+}
+
+// MessageName returns the message type name without a leading pointer prefix.
+// This is useful for metrics where stable type names are preferred.
+// If msg is nil, "<nil>" is returned.
+func MessageName(msg interface{}) string {
+	if msg == nil {
+		return "<nil>"
+	}
+	t := reflect.TypeOf(msg)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t.String()
+}

--- a/actor/middleware/opentelemetry/activespan.go
+++ b/actor/middleware/opentelemetry/activespan.go
@@ -38,7 +38,7 @@ func GetActiveSpan(ctx actor.Context) trace.Span {
 	span := getActiveSpan(ctx.Self())
 	if span == nil {
 		// TODO: Fix finding the real span always or handle no-span better on receiving side
-		bctx, newSpan := otel.Tracer("protoactor/middleware").Start(context.Background(), fmt.Sprintf("%T/%T", ctx.Actor(), ctx.Message()))
+		bctx, newSpan := otel.Tracer("protoactor/middleware").Start(context.Background(), fmt.Sprintf("%T/%s", ctx.Actor(), actor.MessageType(ctx.Message())))
 		_ = bctx
 		span = newSpan
 	}

--- a/actor/middleware/opentelemetry/receivermiddleware.go
+++ b/actor/middleware/opentelemetry/receivermiddleware.go
@@ -40,7 +40,7 @@ func ReceiverMiddleware() actor.ReceiverMiddleware {
 				}
 				parentCtx, span = otel.Tracer("protoactor/middleware").Start(parentCtx, fmt.Sprintf("%T/stopping", c.Actor()))
 				setStoppingSpan(c.Self(), span)
-				span.SetAttributes(attribute.String("ActorPID", c.Self().String()), attribute.String("ActorType", fmt.Sprintf("%T", c.Actor())), attribute.String("MessageType", fmt.Sprintf("%T", envelope.Message)))
+				span.SetAttributes(attribute.String("ActorPID", c.Self().String()), attribute.String("ActorType", fmt.Sprintf("%T", c.Actor())), attribute.String("MessageType", actor.MessageType(envelope.Message)))
 				childCtx, stoppingHandlingSpan := otel.Tracer("protoactor/middleware").Start(parentCtx, "stopping-handling")
 				_ = childCtx
 				next(c, envelope)
@@ -61,14 +61,14 @@ func ReceiverMiddleware() actor.ReceiverMiddleware {
 				} else {
 					c.Logger().Debug("INBOUND Starting span from parent", slog.Any("self", c.Self()), slog.Any("actor", c.Actor()), slog.Any("message", envelope.Message))
 				}
-				ctx, span = otel.Tracer("protoactor/middleware").Start(ctx, fmt.Sprintf("%T/%T", c.Actor(), envelope.Message))
+				ctx, span = otel.Tracer("protoactor/middleware").Start(ctx, fmt.Sprintf("%T/%s", c.Actor(), actor.MessageType(envelope.Message)))
 			}
 
 			setActiveSpan(c.Self(), span)
 			span.SetAttributes(
 				attribute.String("ActorPID", c.Self().String()),
 				attribute.String("ActorType", fmt.Sprintf("%T", c.Actor())),
-				attribute.String("MessageType", fmt.Sprintf("%T", envelope.Message)),
+				attribute.String("MessageType", actor.MessageType(envelope.Message)),
 			)
 
 			defer func() {

--- a/actor/middleware/opentracing/activespan.go
+++ b/actor/middleware/opentracing/activespan.go
@@ -33,7 +33,7 @@ func GetActiveSpan(context actor.Context) opentracing.Span {
 	span := getActiveSpan(context.Self())
 	if span == nil {
 		// TODO: Fix finding the real span always or handle no-span better on receiving side
-		span = opentracing.StartSpan(fmt.Sprintf("%T/%T", context.Actor(), context.Message()))
+		span = opentracing.StartSpan(fmt.Sprintf("%T/%s", context.Actor(), actor.MessageType(context.Message())))
 	}
 
 	return span

--- a/actor/middleware/opentracing/receivermiddleware.go
+++ b/actor/middleware/opentracing/receivermiddleware.go
@@ -25,7 +25,7 @@ func ReceiverMiddleware() actor.ReceiverMiddleware {
 			case *actor.Started:
 				parentSpan := getAndClearParentSpan(c.Self())
 				if parentSpan != nil {
-					span = opentracing.StartSpan(fmt.Sprintf("%T/%T", c.Actor(), envelope.Message), opentracing.ChildOf(parentSpan.Context()))
+					span = opentracing.StartSpan(fmt.Sprintf("%T/%s", c.Actor(), actor.MessageType(envelope.Message)), opentracing.ChildOf(parentSpan.Context()))
 					c.Logger().Debug("INBOUND Found parent span", slog.Any("self", c.Self()), slog.Any("actor", c.Actor()), slog.Any("message", envelope.Message))
 				} else {
 					c.Logger().Debug("INBOUND No parent span", slog.Any("self", c.Self()), slog.Any("actor", c.Actor()), slog.Any("message", envelope.Message))
@@ -43,7 +43,7 @@ func ReceiverMiddleware() actor.ReceiverMiddleware {
 				setStoppingSpan(c.Self(), span)
 				span.SetTag("ActorPID", c.Self())
 				span.SetTag("ActorType", fmt.Sprintf("%T", c.Actor()))
-				span.SetTag("MessageType", fmt.Sprintf("%T", envelope.Message))
+				span.SetTag("MessageType", actor.MessageType(envelope.Message))
 				stoppingHandlingSpan := opentracing.StartSpan("stopping-handling", opentracing.ChildOf(span.Context()))
 				next(c, envelope)
 				stoppingHandlingSpan.Finish()
@@ -58,17 +58,17 @@ func ReceiverMiddleware() actor.ReceiverMiddleware {
 			}
 			if span == nil && spanContext == nil {
 				c.Logger().Debug("INBOUND No spanContext. Starting new span", slog.Any("self", c.Self()), slog.Any("actor", c.Actor()), slog.Any("message", envelope.Message))
-				span = opentracing.StartSpan(fmt.Sprintf("%T/%T", c.Actor(), envelope.Message))
+				span = opentracing.StartSpan(fmt.Sprintf("%T/%s", c.Actor(), actor.MessageType(envelope.Message)))
 			}
 			if span == nil {
 				c.Logger().Debug("INBOUND Starting span from parent", slog.Any("self", c.Self()), slog.Any("actor", c.Actor()), slog.Any("message", envelope.Message))
-				span = opentracing.StartSpan(fmt.Sprintf("%T/%T", c.Actor(), envelope.Message), opentracing.ChildOf(spanContext))
+				span = opentracing.StartSpan(fmt.Sprintf("%T/%s", c.Actor(), actor.MessageType(envelope.Message)), opentracing.ChildOf(spanContext))
 			}
 
 			setActiveSpan(c.Self(), span)
 			span.SetTag("ActorPID", c.Self())
 			span.SetTag("ActorType", fmt.Sprintf("%T", c.Actor()))
-			span.SetTag("MessageType", fmt.Sprintf("%T", envelope.Message))
+			span.SetTag("MessageType", actor.MessageType(envelope.Message))
 
 			defer func() {
 				c.Logger().Debug("INBOUND Finishing span", slog.Any("self", c.Self()), slog.Any("actor", c.Actor()), slog.Any("message", envelope.Message))

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -9,6 +9,7 @@ import (
 	"github.com/asynkron/gofun/set"
 
 	"github.com/asynkron/protoactor-go/actor"
+	clustermetrics "github.com/asynkron/protoactor-go/cluster/metrics"
 	"github.com/asynkron/protoactor-go/extensions"
 	"github.com/asynkron/protoactor-go/remote"
 )
@@ -26,6 +27,9 @@ type Cluster struct {
 	IdentityLookup IdentityLookup
 	kinds          map[string]*ActivatedKind
 	context        Context
+
+	metrics        *clustermetrics.ClusterMetrics
+	metricsEnabled bool
 }
 
 var _ extensions.Extension = &Cluster{}
@@ -37,6 +41,11 @@ func New(actorSystem *actor.ActorSystem, config *Config) *Cluster {
 		kinds:       map[string]*ActivatedKind{},
 	}
 	actorSystem.Extensions.Register(c)
+
+	if actorSystem.Config.MetricsEnabled {
+		c.metrics = clustermetrics.NewClusterMetrics(actorSystem.Logger())
+		c.metricsEnabled = true
+	}
 
 	c.context = config.ClusterContextProducer(c)
 	c.PidCache = NewPidCache()
@@ -62,8 +71,23 @@ func (c *Cluster) subscribeToTopologyEvents() {
 			for _, member := range clusterTopology.Left {
 				c.PidCache.RemoveByMember(member)
 			}
+			if c.metricsEnabled {
+				c.metrics.ClusterMembersCount.Set(int64(len(clusterTopology.Members)))
+			}
 		}
 	})
+}
+
+func (c *Cluster) MetricsEnabled() bool { return c.metricsEnabled }
+
+func (c *Cluster) Metrics() *clustermetrics.ClusterMetrics { return c.metrics }
+
+func (c *Cluster) VirtualActorCount() int64 {
+	var total int64
+	for _, k := range c.kinds {
+		total += int64(k.Count())
+	}
+	return total
 }
 
 func (c *Cluster) ExtensionID() extensions.ExtensionID {

--- a/cluster/default_context.go
+++ b/cluster/default_context.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/asynkron/protoactor-go/actor"
 	"github.com/asynkron/protoactor-go/remote"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // Defines a type to provide DefaultContext configurations / implementations.
@@ -59,6 +61,9 @@ func (dcc *DefaultContext) Request(identity, kind string, message interface{}, o
 	ctx, cancel := context.WithTimeout(context.Background(), ttl)
 	defer cancel()
 
+	var fromCache bool
+	var pid *actor.PID
+
 selectloop:
 	for {
 		select {
@@ -73,10 +78,20 @@ selectloop:
 
 				break selectloop
 			}
-			pid := dcc.getPid(identity, kind)
+			pid, fromCache = dcc.getPid(identity, kind)
 			if pid == nil {
 				dcc.cluster.Logger().Debug("Requesting PID from IdentityLookup but got nil", slog.String("identity", identity), slog.String("kind", kind))
 				counter = callConfig.RetryAction(counter)
+				if dcc.cluster.metricsEnabled {
+					_ctx := context.Background()
+					attrs := []attribute.KeyValue{
+						attribute.String("id", dcc.cluster.ActorSystem.ID),
+						attribute.String("address", dcc.cluster.ActorSystem.Address()),
+						attribute.String("clusterkind", kind),
+						attribute.String("messagetype", actor.MessageName(message)),
+					}
+					dcc.cluster.metrics.ClusterRequestRetryCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
+				}
 				continue
 			}
 
@@ -91,18 +106,40 @@ selectloop:
 				case actor.ErrTimeout, remote.ErrTimeout, actor.ErrDeadLetter, remote.ErrDeadLetter:
 					counter = callConfig.RetryAction(counter)
 					dcc.cluster.PidCache.Remove(identity, kind)
+					if dcc.cluster.metricsEnabled {
+						_ctx := context.Background()
+						attrs := []attribute.KeyValue{
+							attribute.String("id", dcc.cluster.ActorSystem.ID),
+							attribute.String("address", dcc.cluster.ActorSystem.Address()),
+							attribute.String("clusterkind", kind),
+							attribute.String("messagetype", actor.MessageName(message)),
+						}
+						dcc.cluster.metrics.ClusterRequestRetryCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
+					}
 					continue
 				default:
 					break selectloop
 				}
 			}
-
-			// TODO: add metrics to increment retries
 		}
 	}
 
 	totalTime := time.Since(start)
-	// TODO: add metrics ot set histogram for total request time
+	if dcc.cluster.metricsEnabled {
+		_ctx := context.Background()
+		source := "IIdentityLookup"
+		if fromCache {
+			source = "PidCache"
+		}
+		attrs := []attribute.KeyValue{
+			attribute.String("id", dcc.cluster.ActorSystem.ID),
+			attribute.String("address", dcc.cluster.ActorSystem.Address()),
+			attribute.String("clusterkind", kind),
+			attribute.String("messagetype", actor.MessageName(message)),
+			attribute.String("pidsource", source),
+		}
+		dcc.cluster.metrics.ClusterRequestDuration.Record(_ctx, totalTime.Seconds(), metric.WithAttributes(attrs...))
+	}
 
 	if contextError := ctx.Err(); contextError != nil && cfg.requestLogThrottle() == actor.Open {
 		// context timeout exceeded, report and return
@@ -140,10 +177,20 @@ func (dcc *DefaultContext) RequestFuture(identity string, kind string, message i
 				return nil, fmt.Errorf("have reached max retries: %v", callConfig.RetryCount)
 			}
 
-			pid := dcc.getPid(identity, kind)
+			pid, _ := dcc.getPid(identity, kind)
 			if pid == nil {
 				dcc.cluster.Logger().Debug("Requesting PID from IdentityLookup but got nil", slog.String("identity", identity), slog.String("kind", kind))
 				counter = callConfig.RetryAction(counter)
+				if dcc.cluster.metricsEnabled {
+					_ctx := context.Background()
+					attrs := []attribute.KeyValue{
+						attribute.String("id", dcc.cluster.ActorSystem.ID),
+						attribute.String("address", dcc.cluster.ActorSystem.Address()),
+						attribute.String("clusterkind", kind),
+						attribute.String("messagetype", actor.MessageName(message)),
+					}
+					dcc.cluster.metrics.ClusterRequestRetryCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
+				}
 				continue
 			}
 
@@ -155,14 +202,32 @@ func (dcc *DefaultContext) RequestFuture(identity string, kind string, message i
 
 // gets the cached PID for the given identity
 // it can return nil if none is found.
-func (dcc *DefaultContext) getPid(identity, kind string) *actor.PID {
-	pid, _ := dcc.cluster.PidCache.Get(identity, kind)
-	if pid == nil {
+func (dcc *DefaultContext) getPid(identity, kind string) (*actor.PID, bool) {
+	if pid, ok := dcc.cluster.PidCache.Get(identity, kind); ok {
+		return pid, true
+	}
+
+	var pid *actor.PID
+	if dcc.cluster.metricsEnabled {
+		start := time.Now()
+		pid = dcc.cluster.Get(identity, kind)
+		if pid != nil {
+			dcc.cluster.PidCache.Set(identity, kind, pid)
+		}
+		elapsed := time.Since(start)
+		_ctx := context.Background()
+		attrs := []attribute.KeyValue{
+			attribute.String("id", dcc.cluster.ActorSystem.ID),
+			attribute.String("address", dcc.cluster.ActorSystem.Address()),
+			attribute.String("clusterkind", kind),
+		}
+		dcc.cluster.metrics.ClusterResolvePidDuration.Record(_ctx, elapsed.Seconds(), metric.WithAttributes(attrs...))
+	} else {
 		pid = dcc.cluster.Get(identity, kind)
 		if pid != nil {
 			dcc.cluster.PidCache.Set(identity, kind, pid)
 		}
 	}
 
-	return pid
+	return pid, false
 }

--- a/cluster/identitylookup/disthash/placement_actor.go
+++ b/cluster/identitylookup/disthash/placement_actor.go
@@ -1,10 +1,14 @@
 package disthash
 
 import (
+	"context"
 	"log/slog"
+	"time"
 
 	"github.com/asynkron/protoactor-go/actor"
 	clustering "github.com/asynkron/protoactor-go/cluster"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 type GrainMeta struct {
@@ -50,6 +54,8 @@ func (p *placementActor) onTerminated(msg *actor.Terminated) {
 	found, key, meta := p.pidToMeta(msg.Who)
 	clusterKind := p.cluster.GetClusterKind(meta.ID.Kind)
 	clusterKind.Dec()
+
+	p.updateVirtualActorsGauge()
 
 	activationTerminated := &clustering.ActivationTerminated{
 		Pid:             msg.Who,
@@ -99,8 +105,19 @@ func (p *placementActor) onActivationRequest(msg *clustering.ActivationRequest, 
 
 	props := clustering.WithClusterIdentity(clusterKind.Props, msg.ClusterIdentity)
 
+	start := time.Now()
 	pid := ctx.SpawnPrefix(props, msg.ClusterIdentity.Identity)
 	clusterKind.Inc()
+	if p.cluster.MetricsEnabled() {
+		_ctx := context.Background()
+		attrs := []attribute.KeyValue{
+			attribute.String("id", p.cluster.ActorSystem.ID),
+			attribute.String("address", p.cluster.ActorSystem.Address()),
+			attribute.String("clusterkind", msg.ClusterIdentity.Kind),
+		}
+		p.cluster.Metrics().ClusterActorSpawnDuration.Record(_ctx, time.Since(start).Seconds(), metric.WithAttributes(attrs...))
+		p.updateVirtualActorsGauge()
+	}
 
 	p.actors[key] = GrainMeta{
 		ID:  msg.ClusterIdentity,
@@ -112,6 +129,13 @@ func (p *placementActor) onActivationRequest(msg *clustering.ActivationRequest, 
 	}
 
 	ctx.Respond(response)
+}
+
+func (p *placementActor) updateVirtualActorsGauge() {
+	if !p.cluster.MetricsEnabled() {
+		return
+	}
+	p.cluster.Metrics().VirtualActorsCount.Set(p.cluster.VirtualActorCount())
 }
 
 func (p *placementActor) pidToMeta(pid *actor.PID) (bool, *string, *GrainMeta) {


### PR DESCRIPTION
## Summary
- track cluster member and virtual actor counts via OTEL metrics
- record request retries, request duration, resolve PID timing, and spawn duration
- centralize message type naming with helper functions used across metrics and tracing

## Testing
- `go test ./actor/...`
- `go test ./cluster`
- `go test ./cluster/identitylookup/disthash`
- `go test ./cluster/clusterproviders/consul -run Test` *(fails: dial tcp 127.0.0.1:8500: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689b988f22ec83288633b8596eb801c8