### PR TITLE
Unify OpenTelemetry labels across modules

### DIFF
--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -80,11 +80,9 @@ func (dp *deadLetterProcess) SendUserMessage(pid *PID, message interface{}) {
 		if ok && metricsSystem.Enabled() {
 			ctx := context.Background()
 			if instruments := metricsSystem.metrics.Get(metrics.InternalActorMetrics); instruments != nil {
-				labels := []attribute.KeyValue{
-					attribute.String("address", dp.actorSystem.Address()),
-					attribute.String("id", dp.actorSystem.ID),
+				labels := append(SystemLabels(dp.actorSystem),
 					attribute.String("messagetype", MessageName(msg)),
-				}
+				)
 
 				instruments.DeadLetterCount.Add(ctx, 1, metric.WithAttributes(labels...))
 			}

--- a/actor/future.go
+++ b/actor/future.go
@@ -10,7 +10,6 @@ import (
 	"unsafe"
 
 	"github.com/asynkron/protoactor-go/metrics"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -35,10 +34,7 @@ func NewFuture(actorSystem *ActorSystem, d time.Duration) *Future {
 		if ok && sysMetrics.Enabled() {
 			if instruments := sysMetrics.metrics.Get(metrics.InternalActorMetrics); instruments != nil {
 				ctx := context.Background()
-				labels := []attribute.KeyValue{
-					attribute.String("address", ref.actorSystem.Address()),
-					attribute.String("id", actorSystem.ID),
-				}
+				labels := SystemLabels(ref.actorSystem)
 
 				instruments.FuturesStartedCount.Add(ctx, 1, metric.WithAttributes(labels...))
 			}
@@ -179,10 +175,7 @@ func (ref *futureProcess) instrument() {
 		sysMetrics, ok := ref.actorSystem.Extensions.Get(extensionId).(*Metrics)
 		if ok && sysMetrics.Enabled() {
 			ctx := context.Background()
-			labels := []attribute.KeyValue{
-				attribute.String("address", ref.actorSystem.Address()),
-				attribute.String("id", ref.actorSystem.ID),
-			}
+			labels := SystemLabels(ref.actorSystem)
 
 			instruments := sysMetrics.metrics.Get(metrics.InternalActorMetrics)
 			if instruments != nil {

--- a/actor/metrics.go
+++ b/actor/metrics.go
@@ -51,12 +51,20 @@ func NewMetrics(system *ActorSystem, provider metric.MeterProvider) *Metrics {
 	}
 }
 
-func (m *Metrics) CommonLabels(ctx Context) []attribute.KeyValue {
-	labels := []attribute.KeyValue{
-		attribute.String("address", ctx.ActorSystem().Address()),
-		attribute.String("id", ctx.ActorSystem().ID),
-		attribute.String("actortype", strings.Replace(fmt.Sprintf("%T", ctx.Actor()), "*", "", 1)),
+// SystemLabels returns a standard set of attributes that identify the actor system
+// emitting the metric. These labels are used across modules to maintain
+// consistency in OpenTelemetry reporting.
+func SystemLabels(system *ActorSystem) []attribute.KeyValue {
+	return []attribute.KeyValue{
+		attribute.String("address", system.Address()),
+		attribute.String("id", system.ID),
 	}
+}
 
-	return labels
+// CommonLabels returns the default set of labels for an actor metric, including
+// system-wide labels and the specific actor type.
+func (m *Metrics) CommonLabels(ctx Context) []attribute.KeyValue {
+	return append(SystemLabels(ctx.ActorSystem()),
+		attribute.String("actortype", strings.Replace(fmt.Sprintf("%T", ctx.Actor()), "*", "", 1)),
+	)
 }

--- a/cluster/default_context.go
+++ b/cluster/default_context.go
@@ -84,12 +84,11 @@ selectloop:
 				counter = callConfig.RetryAction(counter)
 				if dcc.cluster.metricsEnabled {
 					_ctx := context.Background()
-					attrs := []attribute.KeyValue{
-						attribute.String("id", dcc.cluster.ActorSystem.ID),
-						attribute.String("address", dcc.cluster.ActorSystem.Address()),
+					attrs := append(
+						actor.SystemLabels(dcc.cluster.ActorSystem),
 						attribute.String("clusterkind", kind),
 						attribute.String("messagetype", actor.MessageName(message)),
-					}
+					)
 					dcc.cluster.metrics.ClusterRequestRetryCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
 				}
 				continue
@@ -108,12 +107,11 @@ selectloop:
 					dcc.cluster.PidCache.Remove(identity, kind)
 					if dcc.cluster.metricsEnabled {
 						_ctx := context.Background()
-						attrs := []attribute.KeyValue{
-							attribute.String("id", dcc.cluster.ActorSystem.ID),
-							attribute.String("address", dcc.cluster.ActorSystem.Address()),
+						attrs := append(
+							actor.SystemLabels(dcc.cluster.ActorSystem),
 							attribute.String("clusterkind", kind),
 							attribute.String("messagetype", actor.MessageName(message)),
-						}
+						)
 						dcc.cluster.metrics.ClusterRequestRetryCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
 					}
 					continue
@@ -131,13 +129,12 @@ selectloop:
 		if fromCache {
 			source = "PidCache"
 		}
-		attrs := []attribute.KeyValue{
-			attribute.String("id", dcc.cluster.ActorSystem.ID),
-			attribute.String("address", dcc.cluster.ActorSystem.Address()),
+		attrs := append(
+			actor.SystemLabels(dcc.cluster.ActorSystem),
 			attribute.String("clusterkind", kind),
 			attribute.String("messagetype", actor.MessageName(message)),
 			attribute.String("pidsource", source),
-		}
+		)
 		dcc.cluster.metrics.ClusterRequestDuration.Record(_ctx, totalTime.Seconds(), metric.WithAttributes(attrs...))
 	}
 
@@ -183,12 +180,11 @@ func (dcc *DefaultContext) RequestFuture(identity string, kind string, message i
 				counter = callConfig.RetryAction(counter)
 				if dcc.cluster.metricsEnabled {
 					_ctx := context.Background()
-					attrs := []attribute.KeyValue{
-						attribute.String("id", dcc.cluster.ActorSystem.ID),
-						attribute.String("address", dcc.cluster.ActorSystem.Address()),
+					attrs := append(
+						actor.SystemLabels(dcc.cluster.ActorSystem),
 						attribute.String("clusterkind", kind),
 						attribute.String("messagetype", actor.MessageName(message)),
-					}
+					)
 					dcc.cluster.metrics.ClusterRequestRetryCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
 				}
 				continue
@@ -216,11 +212,10 @@ func (dcc *DefaultContext) getPid(identity, kind string) (*actor.PID, bool) {
 		}
 		elapsed := time.Since(start)
 		_ctx := context.Background()
-		attrs := []attribute.KeyValue{
-			attribute.String("id", dcc.cluster.ActorSystem.ID),
-			attribute.String("address", dcc.cluster.ActorSystem.Address()),
+		attrs := append(
+			actor.SystemLabels(dcc.cluster.ActorSystem),
 			attribute.String("clusterkind", kind),
-		}
+		)
 		dcc.cluster.metrics.ClusterResolvePidDuration.Record(_ctx, elapsed.Seconds(), metric.WithAttributes(attrs...))
 	} else {
 		pid = dcc.cluster.Get(identity, kind)

--- a/cluster/identitylookup/disthash/placement_actor.go
+++ b/cluster/identitylookup/disthash/placement_actor.go
@@ -110,11 +110,10 @@ func (p *placementActor) onActivationRequest(msg *clustering.ActivationRequest, 
 	clusterKind.Inc()
 	if p.cluster.MetricsEnabled() {
 		_ctx := context.Background()
-		attrs := []attribute.KeyValue{
-			attribute.String("id", p.cluster.ActorSystem.ID),
-			attribute.String("address", p.cluster.ActorSystem.Address()),
+		attrs := append(
+			actor.SystemLabels(p.cluster.ActorSystem),
 			attribute.String("clusterkind", msg.ClusterIdentity.Kind),
-		}
+		)
 		p.cluster.Metrics().ClusterActorSpawnDuration.Record(_ctx, time.Since(start).Seconds(), metric.WithAttributes(attrs...))
 		p.updateVirtualActorsGauge()
 	}

--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -117,7 +117,7 @@ func (a *activator) Receive(context actor.Context) {
 		if err == nil {
 			if a.remote.metricsEnabled {
 				_ctx := context2.Background()
-				attrs := append(a.remote.commonLabels(), attribute.String("kind", msg.Kind))
+				attrs := append(actor.SystemLabels(a.remote.actorSystem), attribute.String("kind", msg.Kind))
 				a.remote.metrics.RemoteActorSpawnCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
 			}
 

--- a/remote/endpoint_reader.go
+++ b/remote/endpoint_reader.go
@@ -140,7 +140,7 @@ func (s *endpointReader) onMessageBatch(m *MessageBatch) error {
 		typeName := m.TypeNames[envelope.TypeId]
 		if s.remote.metricsEnabled {
 			_ctx := context.Background()
-			attrs := append(s.remote.commonLabels(), attribute.String("messagetype", typeName))
+			attrs := append(actor.SystemLabels(s.remote.actorSystem), attribute.String("messagetype", typeName))
 			s.remote.metrics.RemoteDeserializedMessageCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
 		}
 

--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -156,7 +156,7 @@ func (state *endpointWriter) initializeInternal() error {
 
 	if state.remote.metricsEnabled {
 		_ctx := context.Background()
-		attrs := append(state.remote.commonLabels(), attribute.String("destinationaddress", state.address))
+		attrs := append(actor.SystemLabels(state.remote.actorSystem), attribute.String("destinationaddress", state.address))
 		state.remote.metrics.RemoteEndpointConnectedCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
 	}
 
@@ -231,7 +231,7 @@ func (state *endpointWriter) sendEnvelopes(msg []interface{}, ctx actor.Context)
 
 		if state.remote.metricsEnabled {
 			_ctx := context.Background()
-			attrs := append(state.remote.commonLabels(), attribute.String("messagetype", typeName))
+			attrs := append(actor.SystemLabels(state.remote.actorSystem), attribute.String("messagetype", typeName))
 			state.remote.metrics.RemoteSerializedMessageCount.Add(_ctx, 1, metric.WithAttributes(attrs...))
 		}
 
@@ -275,7 +275,7 @@ func (state *endpointWriter) sendEnvelopes(msg []interface{}, ctx actor.Context)
 
 	if state.remote.metricsEnabled {
 		_ctx := context.Background()
-		attrs := append(state.remote.commonLabels(), attribute.String("destinationaddress", state.address))
+		attrs := append(actor.SystemLabels(state.remote.actorSystem), attribute.String("destinationaddress", state.address))
 		state.remote.metrics.RemoteWriteDuration.Record(_ctx, time.Since(start).Seconds(), metric.WithAttributes(attrs...))
 	}
 
@@ -359,7 +359,7 @@ func (state *endpointWriter) closeClientConn() {
 
 	if state.remote.metricsEnabled {
 		_ctx := context.Background()
-		state.remote.metrics.RemoteEndpointDisconnectedCount.Add(_ctx, 1, metric.WithAttributes(state.remote.commonLabels()...))
+		state.remote.metrics.RemoteEndpointDisconnectedCount.Add(_ctx, 1, metric.WithAttributes(actor.SystemLabels(state.remote.actorSystem)...))
 	}
 	if state.stream != nil {
 		err := state.stream.CloseSend()

--- a/remote/server.go
+++ b/remote/server.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/asynkron/protoactor-go/actor"
 	remotemetrics "github.com/asynkron/protoactor-go/remote/metrics"
-	"go.opentelemetry.io/otel/attribute"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/grpclog"
 )
@@ -64,13 +63,6 @@ func (r *Remote) ExtensionID() extensions.ExtensionID {
 }
 
 func (r *Remote) BlockList() *BlockList { return r.blocklist }
-
-func (r *Remote) commonLabels() []attribute.KeyValue {
-	return []attribute.KeyValue{
-		attribute.String("id", r.actorSystem.ID),
-		attribute.String("address", r.actorSystem.Address()),
-	}
-}
 
 // Start the remote server
 func (r *Remote) Start() {


### PR DESCRIPTION
## Summary
- centralize standard OpenTelemetry attributes with `SystemLabels`
- replace ad-hoc label creation in actor, cluster, and remote packages
- ensure metrics across modules use the same base labels

## Testing
- `go test ./actor/... ./remote/...`
- `go test ./cluster/...` *(fails: dial tcp 127.0.0.1:8500: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689ba53ee9148328a20eb3fd6df0ca23