### PR TITLE
docs: add package comments for core modules

### DIFF
--- a/actor/middleware/logging.go
+++ b/actor/middleware/logging.go
@@ -1,3 +1,4 @@
+// Package middleware provides reusable actor middleware components.
 package middleware
 
 import (

--- a/actor/middleware/opentelemetry/activespan.go
+++ b/actor/middleware/opentelemetry/activespan.go
@@ -1,3 +1,4 @@
+// Package opentelemetry provides OpenTelemetry tracing middleware for actors.
 package opentelemetry
 
 import (

--- a/actor/middleware/opentracing/activespan.go
+++ b/actor/middleware/opentracing/activespan.go
@@ -1,3 +1,4 @@
+// Package opentracing integrates OpenTracing with Proto.Actor.
 package opentracing
 
 import (

--- a/actor/middleware/propagator/middlewarepropagation.go
+++ b/actor/middleware/propagator/middlewarepropagation.go
@@ -1,3 +1,4 @@
+// Package propagator offers utilities for forwarding middleware and decorators.
 package propagator
 
 import (

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -1,3 +1,4 @@
+// Package cluster enables distributed actors and grain management.
 package cluster
 
 import (

--- a/cluster/cluster_test_tool/cluster_fixture.go
+++ b/cluster/cluster_test_tool/cluster_fixture.go
@@ -1,3 +1,4 @@
+// Package cluster_test_tool offers utilities for cluster-related tests.
 package cluster_test_tool
 
 import (

--- a/cluster/clusterproviders/automanaged/automanaged.go
+++ b/cluster/clusterproviders/automanaged/automanaged.go
@@ -1,3 +1,4 @@
+// Package automanaged provides a simple cluster provider for development and tests.
 package automanaged
 
 import (

--- a/cluster/clusterproviders/consul/consul_provider.go
+++ b/cluster/clusterproviders/consul/consul_provider.go
@@ -1,3 +1,4 @@
+// Package consul provides a Consul-based cluster provider.
 package consul
 
 import (

--- a/cluster/clusterproviders/etcd/config.go
+++ b/cluster/clusterproviders/etcd/config.go
@@ -1,3 +1,4 @@
+// Package etcd contains options for configuring an etcd-based cluster provider.
 package etcd
 
 import (

--- a/cluster/clusterproviders/k8s/k8s_cluster_monitor.go
+++ b/cluster/clusterproviders/k8s/k8s_cluster_monitor.go
@@ -1,3 +1,4 @@
+// Package k8s implements a Kubernetes-based cluster provider.
 package k8s
 
 import (

--- a/cluster/clusterproviders/test/log.go
+++ b/cluster/clusterproviders/test/log.go
@@ -1,1 +1,2 @@
+// Package test provides helpers for testing cluster providers.
 package test

--- a/cluster/clusterproviders/zk/config.go
+++ b/cluster/clusterproviders/zk/config.go
@@ -1,3 +1,4 @@
+// Package zk provides ZooKeeper-based cluster provider configuration.
 package zk
 
 import (

--- a/cluster/identitylookup/disthash/identity_lookup.go
+++ b/cluster/identitylookup/disthash/identity_lookup.go
@@ -1,3 +1,4 @@
+// Package disthash implements a distributed hash-based identity lookup.
 package disthash
 
 import (

--- a/cluster/messages.go
+++ b/cluster/messages.go
@@ -1,3 +1,4 @@
+// Package cluster defines messages used by the cluster infrastructure.
 package cluster
 
 import (
@@ -84,16 +85,19 @@ type SendGossipStateResponse struct{}
 // Used by the GossipActor to respond SetGossipStatus requests
 type SetGossipStateResponse struct{}
 
+// AddConsensusCheck registers a consensus check with the gossip actor.
 type AddConsensusCheck struct {
 	ID    string
 	Check *ConsensusCheck
 }
 
+// RemoveConsensusCheck instructs the gossip actor to remove a consensus check.
 // Mimic .NET ReenterAfterCancellation on GossipActor
 type RemoveConsensusCheck struct {
 	ID string
 }
 
+// NewAddConsensusCheck creates a new AddConsensusCheck message.
 func NewAddConsensusCheck(id string, check *ConsensusCheck) AddConsensusCheck {
 	value := AddConsensusCheck{
 		ID:    id,
@@ -102,6 +106,7 @@ func NewAddConsensusCheck(id string, check *ConsensusCheck) AddConsensusCheck {
 	return value
 }
 
+// NewRemoveConsensusCheck creates a new RemoveConsensusCheck message.
 func NewRemoveConsensusCheck(id string) RemoveConsensusCheck {
 	value := RemoveConsensusCheck{
 		ID: id,

--- a/cluster/metrics/cluster_metrics.go
+++ b/cluster/metrics/cluster_metrics.go
@@ -1,3 +1,4 @@
+// Package clustermetrics reports cluster metrics via OpenTelemetry.
 package clustermetrics
 
 import (

--- a/remote/metrics/remote_metrics.go
+++ b/remote/metrics/remote_metrics.go
@@ -1,3 +1,4 @@
+// Package remotemetrics collects metrics for remote actors using OpenTelemetry.
 package remotemetrics
 
 import (


### PR DESCRIPTION
## Summary
- add missing package docs for actor middleware and remote metrics
- document cluster providers and core cluster package
- clarify consensus check message helpers

## Testing
- `make lint`
- `make test` *(fails: github.com/asynkron/protoactor-go/cluster/clusterproviders/zk)*

------
https://chatgpt.com/codex/tasks/task_e_689c24b7aa0c832887b2b85ea1d9bd1a