### PR TITLE
docs: add missing remote comments

### DIFF
--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -35,6 +35,8 @@ type activator struct {
 // Partition will then find next available Activator to spawn
 var ErrActivatorUnavailable = &ActivatorError{ResponseStatusCodeUNAVAILABLE.ToInt32(), true}
 
+// ActivatorError represents an error returned from the activator and controls
+// whether the activator should panic when it occurs.
 type ActivatorError struct {
 	Code       int32
 	DoNotPanic bool

--- a/remote/blocklist.go
+++ b/remote/blocklist.go
@@ -10,12 +10,13 @@ import (
 	"github.com/asynkron/gofun/set"
 )
 
-// TODO: document it
+// BlockList keeps track of blocked cluster member IDs.
 type BlockList struct {
 	mu             *sync.RWMutex
 	blockedMembers *set.ImmutableSet[string]
 }
 
+// NewBlockList creates an empty BlockList.
 func NewBlockList() *BlockList {
 	blocklist := BlockList{
 		mu:             &sync.RWMutex{},
@@ -24,6 +25,7 @@ func NewBlockList() *BlockList {
 	return &blocklist
 }
 
+// BlockedMembers returns the set of blocked member IDs.
 func (bl *BlockList) BlockedMembers() set.Set[string] {
 	return bl.blockedMembers
 }

--- a/remote/config-opts.go
+++ b/remote/config-opts.go
@@ -2,6 +2,7 @@ package remote
 
 import "google.golang.org/grpc"
 
+// ConfigOption configures a Remote instance.
 type ConfigOption func(config *Config)
 
 // WithEndpointWriterBatchSize sets the batch size for the endpoint writer

--- a/remote/endpoint_manager.go
+++ b/remote/endpoint_manager.go
@@ -19,6 +19,7 @@ type endpointLazy struct {
 	address  string
 }
 
+// NewEndpointLazy creates an endpoint that connects to the remote address on first use.
 func NewEndpointLazy(em *endpointManager, address string) *endpointLazy {
 	return &endpointLazy{
 		manager: em,

--- a/remote/errors.go
+++ b/remote/errors.go
@@ -1,11 +1,16 @@
 package remote
 
 var (
-	ErrUnAvailable             = &ResponseError{ResponseStatusCodeUNAVAILABLE}
-	ErrTimeout                 = &ResponseError{ResponseStatusCodeTIMEOUT}
+	// ErrUnAvailable is returned when the remote endpoint is unavailable.
+	ErrUnAvailable = &ResponseError{ResponseStatusCodeUNAVAILABLE}
+	// ErrTimeout is returned when a remote call times out.
+	ErrTimeout = &ResponseError{ResponseStatusCodeTIMEOUT}
+	// ErrProcessNameAlreadyExist indicates a process name conflict.
 	ErrProcessNameAlreadyExist = &ResponseError{ResponseStatusCodePROCESSNAMEALREADYEXIST}
-	ErrDeadLetter              = &ResponseError{ResponseStatusCodeDeadLetter}
-	ErrUnknownError            = &ResponseError{ResponseStatusCodeERROR}
+	// ErrDeadLetter is returned when the target PID cannot be found.
+	ErrDeadLetter = &ResponseError{ResponseStatusCodeDeadLetter}
+	// ErrUnknownError represents an unspecified remote error.
+	ErrUnknownError = &ResponseError{ResponseStatusCodeERROR}
 )
 
 // ResponseError is an error type.

--- a/remote/messages.go
+++ b/remote/messages.go
@@ -2,10 +2,12 @@ package remote
 
 import "github.com/asynkron/protoactor-go/actor"
 
+// EndpointTerminatedEvent is published when a remote endpoint terminates.
 type EndpointTerminatedEvent struct {
 	Address string
 }
 
+// EndpointConnectedEvent is published when a remote endpoint establishes a connection.
 type EndpointConnectedEvent struct {
 	Address string
 }
@@ -33,6 +35,7 @@ type remoteTerminate struct {
 	Watchee *actor.PID
 }
 
+// JsonMessage carries a JSON encoded message and its type name.
 type JsonMessage struct {
 	TypeName string
 	Json     string
@@ -41,8 +44,11 @@ type JsonMessage struct {
 var stopMessage interface{} = &actor.Stop{}
 
 var (
-	ActorPidRespErr         interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeERROR.ToInt32()}
-	ActorPidRespTimeout     interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeTIMEOUT.ToInt32()}
+	// ActorPidRespErr is returned when spawning an actor results in an error.
+	ActorPidRespErr interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeERROR.ToInt32()}
+	// ActorPidRespTimeout is returned when spawning an actor times out.
+	ActorPidRespTimeout interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeTIMEOUT.ToInt32()}
+	// ActorPidRespUnavailable is returned when the activator is unavailable.
 	ActorPidRespUnavailable interface{} = &ActorPidResponse{StatusCode: ResponseStatusCodeUNAVAILABLE.ToInt32()}
 )
 

--- a/remote/response_status_code.go
+++ b/remote/response_status_code.go
@@ -2,15 +2,23 @@ package remote
 
 import "strconv"
 
+// ResponseStatusCode represents possible outcomes of remote operations.
 type ResponseStatusCode int32
 
 const (
+	// ResponseStatusCodeOK indicates the operation completed successfully.
 	ResponseStatusCodeOK ResponseStatusCode = iota
+	// ResponseStatusCodeUNAVAILABLE indicates the remote endpoint was unavailable.
 	ResponseStatusCodeUNAVAILABLE
+	// ResponseStatusCodeTIMEOUT indicates the operation timed out.
 	ResponseStatusCodeTIMEOUT
+	// ResponseStatusCodePROCESSNAMEALREADYEXIST indicates a process name conflict.
 	ResponseStatusCodePROCESSNAMEALREADYEXIST
+	// ResponseStatusCodeERROR indicates an unspecified error occurred.
 	ResponseStatusCodeERROR
+	// ResponseStatusCodeDeadLetter indicates the target PID could not be found.
 	ResponseStatusCodeDeadLetter
+	// ResponseStatusCodeMAX is a boundary marker for the enum.
 	ResponseStatusCodeMAX // just a boundary.
 )
 
@@ -26,6 +34,7 @@ func init() {
 	responseNames[ResponseStatusCodeDeadLetter] = "ResponseStatusCodeDeadLetter"
 }
 
+// ToInt32 converts the status code to its int32 representation.
 func (c ResponseStatusCode) ToInt32() int32 {
 	return int32(c)
 }
@@ -38,6 +47,7 @@ func (c ResponseStatusCode) String() string {
 	return responseNames[statusCode]
 }
 
+// AsError converts the status code to a ResponseError.
 func (c ResponseStatusCode) AsError() *ResponseError {
 	switch c {
 	case ResponseStatusCodeOK:

--- a/remote/serializer.go
+++ b/remote/serializer.go
@@ -1,6 +1,7 @@
 package remote
 
 var (
+	// DefaultSerializerID is used when no specific serializer is requested.
 	DefaultSerializerID int32
 	serializers         []Serializer
 )
@@ -10,16 +11,19 @@ func init() {
 	RegisterSerializer(newJsonSerializer())
 }
 
+// RegisterSerializer registers a Serializer implementation.
 func RegisterSerializer(serializer Serializer) {
 	serializers = append(serializers, serializer)
 }
 
+// Serializer defines how messages are encoded and decoded.
 type Serializer interface {
 	Serialize(msg interface{}) ([]byte, error)
 	Deserialize(typeName string, bytes []byte) (interface{}, error)
 	GetTypeName(msg interface{}) (string, error)
 }
 
+// Serialize encodes a message using the specified serializer.
 func Serialize(message interface{}, serializerID int32) ([]byte, string, error) {
 	res, err := serializers[serializerID].Serialize(message)
 	if err != nil {
@@ -32,6 +36,7 @@ func Serialize(message interface{}, serializerID int32) ([]byte, string, error) 
 	return res, typeName, nil
 }
 
+// Deserialize decodes a message using the specified serializer.
 func Deserialize(message []byte, typeName string, serializerID int32) (interface{}, error) {
 	return serializers[serializerID].Deserialize(typeName, message)
 }

--- a/remote/server.go
+++ b/remote/server.go
@@ -17,6 +17,7 @@ import (
 
 var extensionId = extensions.NextExtensionID()
 
+// Remote enables communication between actors across network boundaries.
 type Remote struct {
 	actorSystem    *actor.ActorSystem
 	s              *grpc.Server
@@ -30,6 +31,7 @@ type Remote struct {
 	metricsEnabled bool
 }
 
+// NewRemote creates a new Remote extension for the given actor system.
 func NewRemote(actorSystem *actor.ActorSystem, config *Config) *Remote {
 	r := &Remote{
 		actorSystem: actorSystem,
@@ -51,6 +53,8 @@ func NewRemote(actorSystem *actor.ActorSystem, config *Config) *Remote {
 	return r
 }
 
+// GetRemote retrieves the Remote extension from the actor system.
+//
 //goland:noinspection GoUnusedExportedFunction
 func GetRemote(actorSystem *actor.ActorSystem) *Remote {
 	r := actorSystem.Extensions.Get(extensionId)
@@ -58,13 +62,15 @@ func GetRemote(actorSystem *actor.ActorSystem) *Remote {
 	return r.(*Remote)
 }
 
+// ExtensionID returns the unique ID of the Remote extension.
 func (r *Remote) ExtensionID() extensions.ExtensionID {
 	return extensionId
 }
 
+// BlockList returns the list of blocked members.
 func (r *Remote) BlockList() *BlockList { return r.blocklist }
 
-// Start the remote server
+// Start the remote server.
 func (r *Remote) Start() {
 	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, ioutil.Discard))
 	lis, err := net.Listen("tcp", r.config.Address())
@@ -93,6 +99,8 @@ func (r *Remote) Start() {
 	go r.s.Serve(lis)
 }
 
+// Shutdown stops the remote server. If graceful is true it waits for running
+// requests to finish.
 func (r *Remote) Shutdown(graceful bool) {
 	if graceful {
 		// TODO: need more graceful
@@ -121,6 +129,7 @@ func (r *Remote) Shutdown(graceful bool) {
 	}
 }
 
+// SendMessage delivers the given message to the target PID using remoting.
 func (r *Remote) SendMessage(pid *actor.PID, header actor.ReadonlyMessageHeader, message interface{}, sender *actor.PID, serializerID int32) {
 	rd := &remoteDeliver{
 		header:       header,
@@ -132,6 +141,7 @@ func (r *Remote) SendMessage(pid *actor.PID, header actor.ReadonlyMessageHeader,
 	r.edpManager.remoteDeliver(rd)
 }
 
+// Logger returns the logger used by the Remote extension.
 func (r *Remote) Logger() *slog.Logger {
 	return r.actorSystem.Logger()
 }


### PR DESCRIPTION
## Summary
- document exported errors, events, and configuration helpers in remote package
- add comments for Remote extension and response status codes

## Testing
- `golangci-lint run --no-config --enable-only=revive ./remote 2>&1 | head -n 200`
- `go test ./remote -run Test -count=1`
- `go test ./remote/tests -run Test -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689c2c621e10832890a320e64612390e