### PR TITLE
Add comments for cluster linting

### DIFF
--- a/cluster/cluster_identity.go
+++ b/cluster/cluster_identity.go
@@ -5,17 +5,19 @@ import (
 	"github.com/asynkron/protoactor-go/ctxext"
 )
 
+// AsKey formats the identity as "kind/identity".
 func (ci *ClusterIdentity) AsKey() string {
 	return ci.Kind + "/" + ci.Identity
 }
 
 var ciExtensionId = ctxext.NextContextExtensionID()
 
-// remove
+// ToShortString returns a compact string representation of the identity.
 func (ci *ClusterIdentity) ToShortString() string {
 	return ci.Kind + "/" + ci.Identity
 }
 
+// NewClusterIdentity constructs a new ClusterIdentity value.
 func NewClusterIdentity(identity string, kind string) *ClusterIdentity {
 	return &ClusterIdentity{
 		Identity: identity,
@@ -23,14 +25,17 @@ func NewClusterIdentity(identity string, kind string) *ClusterIdentity {
 	}
 }
 
+// ExtensionID implements ctxext.Extension and returns the extension identifier.
 func (ci *ClusterIdentity) ExtensionID() ctxext.ContextExtensionID {
 	return ciExtensionId
 }
 
+// GetClusterIdentity retrieves the ClusterIdentity from the context.
 func GetClusterIdentity(ctx actor.ExtensionContext) *ClusterIdentity {
 	return ctx.Get(ciExtensionId).(*ClusterIdentity)
 }
 
+// SetClusterIdentity stores the ClusterIdentity on the context.
 func SetClusterIdentity(ctx actor.ExtensionContext, ci *ClusterIdentity) {
 	ctx.Set(ci)
 }

--- a/cluster/cluster_test_tool/cluster_fixture.go
+++ b/cluster/cluster_test_tool/cluster_fixture.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// ClusterFixture defines operations for managing a test cluster.
 type ClusterFixture interface {
 	GetMembers() []*cluster.Cluster
 	GetClusterSize() int
@@ -23,6 +24,7 @@ type ClusterFixture interface {
 	ShutDown()
 }
 
+// ClusterFixtureConfig holds configuration for building test clusters.
 type ClusterFixtureConfig struct {
 	GetClusterKinds    func() []*cluster.Kind
 	GetClusterProvider func() cluster.ClusterProvider
@@ -31,6 +33,7 @@ type ClusterFixtureConfig struct {
 	OnDeposing         func()
 }
 
+// ClusterFixtureOption configures a ClusterFixtureConfig.
 type ClusterFixtureOption func(*ClusterFixtureConfig)
 
 // WithGetClusterKinds sets the cluster kinds for the cluster fixture
@@ -68,8 +71,10 @@ func WithOnDeposing(onDeposing func()) ClusterFixtureOption {
 	}
 }
 
+// InvalidIdentity represents a non-existing actor identity used in tests.
 const InvalidIdentity string = "invalid"
 
+// BaseClusterFixture implements common functionality for cluster fixtures.
 type BaseClusterFixture struct {
 	clusterName string
 	clusterSize int
@@ -77,6 +82,7 @@ type BaseClusterFixture struct {
 	members     []*cluster.Cluster
 }
 
+// NewBaseClusterFixture creates a BaseClusterFixture with the given cluster size.
 func NewBaseClusterFixture(clusterSize int, opts ...ClusterFixtureOption) *BaseClusterFixture {
 	config := &ClusterFixtureConfig{
 		GetClusterKinds:    func() []*cluster.Kind { return make([]*cluster.Kind, 0) },
@@ -104,20 +110,24 @@ func (b *BaseClusterFixture) Initialize() {
 	b.members = append(b.members, nodes...)
 }
 
+// GetMembers returns the current cluster members.
 func (b *BaseClusterFixture) GetMembers() []*cluster.Cluster {
 	return b.members
 }
 
+// GetClusterSize returns the expected size of the cluster.
 func (b *BaseClusterFixture) GetClusterSize() int {
 	return b.clusterSize
 }
 
+// SpawnNode adds a new member to the cluster and returns it.
 func (b *BaseClusterFixture) SpawnNode() *cluster.Cluster {
 	node := b.spawnClusterMember()
 	b.members = append(b.members, node)
 	return node
 }
 
+// RemoveNode removes the given member from the cluster.
 func (b *BaseClusterFixture) RemoveNode(node *cluster.Cluster, graceful bool) {
 	has := false
 	for i, member := range b.members {
@@ -133,6 +143,7 @@ func (b *BaseClusterFixture) RemoveNode(node *cluster.Cluster, graceful bool) {
 	}
 }
 
+// ShutDown disposes the fixture and stops all members.
 func (b *BaseClusterFixture) ShutDown() {
 	b.config.OnDeposing()
 	b.waitForMembersToShutdown()

--- a/cluster/cluster_test_tool/pubsub_cluster_fixture.go
+++ b/cluster/cluster_test_tool/pubsub_cluster_fixture.go
@@ -17,10 +17,13 @@ import (
 )
 
 const (
-	PubSubSubscriberKind        = "Subscriber"
+	// PubSubSubscriberKind is the cluster kind used for regular subscribers.
+	PubSubSubscriberKind = "Subscriber"
+	// PubSubTimeoutSubscriberKind is a subscriber kind that intentionally times out.
 	PubSubTimeoutSubscriberKind = "TimeoutSubscriber"
 )
 
+// PubSubClusterFixture simplifies setting up clusters for PubSub testing.
 type PubSubClusterFixture struct {
 	*BaseClusterFixture
 
@@ -33,6 +36,7 @@ type PubSubClusterFixture struct {
 	subscriberStore cluster.KeyValueStore[*cluster.Subscribers]
 }
 
+// NewPubSubClusterFixture creates a new fixture with the given cluster size.
 func NewPubSubClusterFixture(t testing.TB, clusterSize int, useDefaultTopicRegistration bool, opts ...ClusterFixtureOption) *PubSubClusterFixture {
 	lock := &sync.RWMutex{}
 	store := NewInMemorySubscriberStore()
@@ -69,6 +73,7 @@ func NewPubSubClusterFixture(t testing.TB, clusterSize int, useDefaultTopicRegis
 	return fixture
 }
 
+// RandomMember returns a random cluster member from the fixture.
 func (p *PubSubClusterFixture) RandomMember() *cluster.Cluster {
 	members := p.BaseClusterFixture.GetMembers()
 	return members[rand.Intn(len(members))]
@@ -203,26 +208,31 @@ func (p *PubSubClusterFixture) AppendDelivery(delivery Delivery) {
 	p.DeliveriesLock.Unlock()
 }
 
+// Delivery describes a message delivered to a subscriber.
 type Delivery struct {
 	Identity string
 	Data     int
 }
 
+// NewInMemorySubscriberStore returns an in-memory key-value store for subscribers.
 func NewInMemorySubscriberStore() *InMemorySubscribersStore[*cluster.Subscribers] {
 	return &InMemorySubscribersStore[*cluster.Subscribers]{
 		store: &sync.Map{},
 	}
 }
 
+// InMemorySubscribersStore provides a simple concurrent map-based storage.
 type InMemorySubscribersStore[T any] struct {
 	store *sync.Map // map[string]T
 }
 
+// Set stores the value for the given key.
 func (i *InMemorySubscribersStore[T]) Set(_ context.Context, key string, value T) error {
 	i.store.Store(key, value)
 	return nil
 }
 
+// Get retrieves the value for the given key.
 func (i *InMemorySubscribersStore[T]) Get(_ context.Context, key string) (T, error) {
 	var r T
 	value, ok := i.store.Load(key)
@@ -232,6 +242,7 @@ func (i *InMemorySubscribersStore[T]) Get(_ context.Context, key string) (T, err
 	return value.(T), nil
 }
 
+// Clear removes the value associated with the given key.
 func (i *InMemorySubscribersStore[T]) Clear(_ context.Context, key string) error {
 	i.store.Delete(key)
 	return nil

--- a/cluster/cluster_test_tool/wait_helper.go
+++ b/cluster/cluster_test_tool/wait_helper.go
@@ -6,8 +6,10 @@ import (
 	"time"
 )
 
+// DefaultWaitTimeout is the default duration to wait for test conditions.
 const DefaultWaitTimeout = time.Second * 5
 
+// WaitUntil repeatedly checks cond until it returns true or the timeout is reached.
 func WaitUntil(t testing.TB, cond func() bool, errorMsg string, timeout time.Duration) {
 	after := time.After(timeout)
 

--- a/cluster/clusterproviders/automanaged/automanaged.go
+++ b/cluster/clusterproviders/automanaged/automanaged.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// AutoManagedProvider is a simple provider storing cluster state in memory and HTTP endpoints.
 type AutoManagedProvider struct {
 	deregistered               bool
 	shutdown                   bool
@@ -108,6 +109,7 @@ func (p *AutoManagedProvider) init(cluster *cluster.Cluster) error {
 	return nil
 }
 
+// StartMember joins the cluster as a member and begins monitoring status changes.
 func (p *AutoManagedProvider) StartMember(cluster *cluster.Cluster) error {
 	if err := p.init(cluster); err != nil {
 		return err
@@ -117,6 +119,7 @@ func (p *AutoManagedProvider) StartMember(cluster *cluster.Cluster) error {
 	return nil
 }
 
+// StartClient connects to the cluster in client mode without registering this node.
 func (p *AutoManagedProvider) StartClient(cluster *cluster.Cluster) error {
 	if err := p.init(cluster); err != nil {
 		return err

--- a/cluster/clusterproviders/consul/consul_provider.go
+++ b/cluster/clusterproviders/consul/consul_provider.go
@@ -13,8 +13,10 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
+// ProviderShuttingDownError is returned when operations occur during provider shutdown.
 var ProviderShuttingDownError = fmt.Errorf("consul cluster provider is shutting down")
 
+// Provider integrates Consul as a cluster provider for Proto.Actor.
 type Provider struct {
 	cluster            *cluster.Cluster
 	deregistered       bool
@@ -36,10 +38,12 @@ type Provider struct {
 	consulConfig       *api.Config
 }
 
+// New creates a new Consul provider with default configuration.
 func New(opts ...Option) (*Provider, error) {
 	return NewWithConfig(&api.Config{}, opts...)
 }
 
+// NewWithConfig creates a new Consul provider using the supplied Consul config.
 func NewWithConfig(consulConfig *api.Config, opts ...Option) (*Provider, error) {
 	client, err := api.NewClient(consulConfig)
 	if err != nil {
@@ -78,6 +82,7 @@ func (p *Provider) init(c *cluster.Cluster) error {
 	return nil
 }
 
+// StartMember connects the provider to Consul and registers the node as a member.
 func (p *Provider) StartMember(c *cluster.Cluster) error {
 	err := p.init(c)
 	if err != nil {
@@ -95,6 +100,7 @@ func (p *Provider) StartMember(c *cluster.Cluster) error {
 	return nil
 }
 
+// StartClient connects the provider to Consul without registering the node as a member.
 func (p *Provider) StartClient(c *cluster.Cluster) error {
 	if err := p.init(c); err != nil {
 		return err
@@ -104,6 +110,7 @@ func (p *Provider) StartClient(c *cluster.Cluster) error {
 	return nil
 }
 
+// DeregisterMember removes the provider's service registration from Consul.
 func (p *Provider) DeregisterMember() error {
 	err := p.deregisterService()
 	if err != nil {
@@ -114,6 +121,7 @@ func (p *Provider) DeregisterMember() error {
 	return nil
 }
 
+// Shutdown stops the provider and its internal actor.
 func (p *Provider) Shutdown(graceful bool) error {
 	if p.shutdown {
 		return nil

--- a/cluster/clusterproviders/consul/options.go
+++ b/cluster/clusterproviders/consul/options.go
@@ -2,14 +2,17 @@ package consul
 
 import "time"
 
+// Option configures a Consul cluster provider.
 type Option func(p *Provider)
 
+// WithTTL sets the Consul service TTL for the provider.
 func WithTTL(ttl time.Duration) Option {
 	return func(p *Provider) {
 		p.ttl = ttl
 	}
 }
 
+// WithRefreshTTL sets how often the provider refreshes its TTL in Consul.
 func WithRefreshTTL(refreshTTL time.Duration) Option {
 	return func(p *Provider) {
 		p.refreshTTL = refreshTTL

--- a/cluster/clusterproviders/consul/provider_actor.go
+++ b/cluster/clusterproviders/consul/provider_actor.go
@@ -18,8 +18,11 @@ type providerActor struct {
 }
 
 type (
-	RegisterService   struct{}
-	UpdateTTL         struct{}
+	// RegisterService asks the provider actor to register its service in Consul.
+	RegisterService struct{}
+	// UpdateTTL triggers a TTL refresh in Consul for the registered service.
+	UpdateTTL struct{}
+	// MemberListUpdated carries the latest set of cluster members retrieved from Consul.
 	MemberListUpdated struct {
 		members []*cluster.Member
 		index   uint64

--- a/cluster/clusterproviders/etcd/config.go
+++ b/cluster/clusterproviders/etcd/config.go
@@ -5,24 +5,29 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
+// RoleChangedListener receives notifications when the node role changes.
 type RoleChangedListener interface {
 	OnRoleChanged(RoleType)
 }
 
+// Option configures the etcd provider.
 type Option func(*config)
 
+// WithBaseKey sets the base key used for all etcd entries.
 func WithBaseKey(baseKey string) Option {
 	return func(o *config) {
 		o.BaseKey = baseKey
 	}
 }
 
+// WithEtcdConfig sets a custom etcd client configuration.
 func WithEtcdConfig(cfg clientv3.Config) Option {
 	return func(o *config) {
 		o.cfg = cfg
 	}
 }
 
+// WithRoleChangedListener sets a callback for role changes.
 func WithRoleChangedListener(l RoleChangedListener) Option {
 	return func(o *config) {
 		o.RoleChanged = l

--- a/cluster/clusterproviders/etcd/etcd_provider.go
+++ b/cluster/clusterproviders/etcd/etcd_provider.go
@@ -15,6 +15,7 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
+// Provider uses etcd for cluster membership discovery.
 type Provider struct {
 	leaseID       clientv3.LeaseID
 	cluster       *cluster.Cluster
@@ -38,6 +39,7 @@ type Provider struct {
 	roleChangedListener RoleChangedListener
 }
 
+// New creates a provider with default etcd configuration.
 func New() (*Provider, error) {
 	return NewWithConfig("/protoactor", clientv3.Config{
 		Endpoints:   []string{"127.0.0.1:2379"},
@@ -45,6 +47,7 @@ func New() (*Provider, error) {
 	})
 }
 
+// NewWithConfig creates a provider using the specified etcd configuration.
 func NewWithConfig(baseKey string, cfg clientv3.Config, opts ...Option) (*Provider, error) {
 	c := defaultConfig()
 	WithBaseKey(baseKey)(c)
@@ -88,6 +91,7 @@ func (p *Provider) init(c *cluster.Cluster) error {
 	return nil
 }
 
+// StartMember registers the node in etcd and starts watching for updates.
 func (p *Provider) StartMember(c *cluster.Cluster) error {
 	if err := p.init(c); err != nil {
 		return err
@@ -114,6 +118,7 @@ func (p *Provider) StartMember(c *cluster.Cluster) error {
 	return nil
 }
 
+// StartClient initializes the provider without registering the node.
 func (p *Provider) StartClient(c *cluster.Cluster) error {
 	if err := p.init(c); err != nil {
 		return err
@@ -129,6 +134,7 @@ func (p *Provider) StartClient(c *cluster.Cluster) error {
 	return nil
 }
 
+// Shutdown deregisters the node and stops background tasks.
 func (p *Provider) Shutdown(graceful bool) error {
 	p.shutdown = true
 	if !p.deregistered {
@@ -460,6 +466,7 @@ func splitHostPort(addr string) (host string, port int, err error) {
 	return
 }
 
+// RegisterSingletonScheduler adds a singleton scheduler to be notified on role changes.
 func (p *Provider) RegisterSingletonScheduler(scheduler *SingletonScheduler) {
 	p.schedulers = append(p.schedulers, scheduler)
 }

--- a/cluster/clusterproviders/etcd/node.go
+++ b/cluster/clusterproviders/etcd/node.go
@@ -12,6 +12,7 @@ const (
 	metaKeySeq = "seq"
 )
 
+// Node represents a cluster member stored in etcd.
 type Node struct {
 	ID      string            `json:"id"`
 	Name    string            `json:"name"`
@@ -23,6 +24,7 @@ type Node struct {
 	Alive   bool              `json:"alive"`
 }
 
+// NewNode constructs a new Node instance.
 func NewNode(name, host string, port int, kinds []string) *Node {
 	return &Node{
 		ID:      name,
@@ -36,6 +38,7 @@ func NewNode(name, host string, port int, kinds []string) *Node {
 	}
 }
 
+// NewNodeFromBytes decodes a Node from its JSON representation.
 func NewNodeFromBytes(data []byte) (*Node, error) {
 	n := Node{}
 	if err := json.Unmarshal(data, &n); err != nil {
@@ -44,6 +47,7 @@ func NewNodeFromBytes(data []byte) (*Node, error) {
 	return &n, nil
 }
 
+// GetAddress returns the host and port for the node.
 func (n *Node) GetAddress() (host string, port int) {
 	host = n.Host
 	port = n.Port
@@ -53,6 +57,7 @@ func (n *Node) GetAddress() (host string, port int) {
 	return
 }
 
+// Equal compares two nodes by ID.
 func (n *Node) Equal(other *Node) bool {
 	if n == nil || other == nil {
 		return false
@@ -63,6 +68,7 @@ func (n *Node) Equal(other *Node) bool {
 	return n.ID == other.ID
 }
 
+// GetMeta returns a metadata value by name.
 func (n *Node) GetMeta(name string) (string, bool) {
 	if n.Meta == nil {
 		return "", false
@@ -70,6 +76,8 @@ func (n *Node) GetMeta(name string) (string, bool) {
 	val, ok := n.Meta[name]
 	return val, ok
 }
+
+// GetSeq returns the sequence number from metadata.
 func (n *Node) GetSeq() int {
 	if seqStr, ok := n.GetMeta(metaKeySeq); ok {
 		return strToInt(seqStr)
@@ -82,6 +90,7 @@ func strToInt(s string) int {
 	return int(i)
 }
 
+// MemberStatus converts the node into a cluster.Member description.
 func (n *Node) MemberStatus() *cluster.Member {
 	host, port := n.GetAddress()
 	kinds := n.Kinds
@@ -96,6 +105,7 @@ func (n *Node) MemberStatus() *cluster.Member {
 	}
 }
 
+// SetMeta sets a metadata value.
 func (n *Node) SetMeta(name string, val string) {
 	if n.Meta == nil {
 		n.Meta = map[string]string{}
@@ -103,6 +113,7 @@ func (n *Node) SetMeta(name string, val string) {
 	n.Meta[name] = val
 }
 
+// Serialize encodes the node to JSON.
 func (n *Node) Serialize() ([]byte, error) {
 	data, err := json.Marshal(n)
 	if err != nil {
@@ -111,14 +122,17 @@ func (n *Node) Serialize() ([]byte, error) {
 	return data, nil
 }
 
+// Deserialize populates the node from JSON data.
 func (n *Node) Deserialize(data []byte) error {
 	return json.Unmarshal(data, n)
 }
 
+// IsAlive reports whether the node is considered alive.
 func (n *Node) IsAlive() bool {
 	return n.Alive
 }
 
+// SetAlive updates the alive flag for the node.
 func (n *Node) SetAlive(alive bool) {
 	n.Alive = alive
 }

--- a/cluster/clusterproviders/etcd/singleton.go
+++ b/cluster/clusterproviders/etcd/singleton.go
@@ -9,7 +9,9 @@ import (
 type RoleType int
 
 const (
+	// Follower indicates the node is not the leader.
 	Follower RoleType = iota
+	// Leader indicates the node currently holds leadership.
 	Leader
 )
 
@@ -30,10 +32,12 @@ type SingletonScheduler struct {
 	pids  []*actor.PID
 }
 
+// NewSingletonScheduler creates a new scheduler bound to the given root context.
 func NewSingletonScheduler(rc *actor.RootContext) *SingletonScheduler {
 	return &SingletonScheduler{root: rc}
 }
 
+// FromFunc registers an actor function to run when the node becomes leader.
 func (s *SingletonScheduler) FromFunc(f actor.ReceiveFunc) *SingletonScheduler {
 	s.Lock()
 	defer s.Unlock()
@@ -41,6 +45,7 @@ func (s *SingletonScheduler) FromFunc(f actor.ReceiveFunc) *SingletonScheduler {
 	return s
 }
 
+// FromProducer registers an actor producer to run when the node becomes leader.
 func (s *SingletonScheduler) FromProducer(f actor.Producer) *SingletonScheduler {
 	s.Lock()
 	defer s.Unlock()
@@ -48,6 +53,7 @@ func (s *SingletonScheduler) FromProducer(f actor.Producer) *SingletonScheduler 
 	return s
 }
 
+// OnRoleChanged reacts to leadership changes and spawns or poisons actors accordingly.
 func (s *SingletonScheduler) OnRoleChanged(rt RoleType) {
 	s.Lock()
 	defer s.Unlock()

--- a/cluster/clusterproviders/test/test_provider.go
+++ b/cluster/clusterproviders/test/test_provider.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+// ProviderConfig holds configuration values for the in-memory test provider.
 type ProviderConfig struct {
 	// ServiceTtl is the time to live for services. Default: 3s
 	ServiceTtl time.Duration
@@ -18,6 +19,7 @@ type ProviderConfig struct {
 	DeregisterCritical time.Duration
 }
 
+// ProviderOption configures a test provider instance.
 type ProviderOption func(config *ProviderConfig)
 
 // WithTestProviderServiceTtl sets the service ttl. Default: 3s
@@ -41,6 +43,7 @@ func WithTestProviderDeregisterCritical(deregisterCritical time.Duration) Provid
 	}
 }
 
+// Provider implements cluster.ClusterProvider using an in-memory agent.
 type Provider struct {
 	memberList *cluster.MemberList
 	config     *ProviderConfig
@@ -51,6 +54,7 @@ type Provider struct {
 	cluster         *cluster.Cluster
 }
 
+// NewTestProvider creates a new Provider backed by the given in-memory agent.
 func NewTestProvider(agent *InMemAgent, options ...ProviderOption) *Provider {
 	config := &ProviderConfig{
 		ServiceTtl:         time.Second * 3,
@@ -66,6 +70,7 @@ func NewTestProvider(agent *InMemAgent, options ...ProviderOption) *Provider {
 	}
 }
 
+// StartMember starts the provider as a cluster member.
 func (t *Provider) StartMember(c *cluster.Cluster) error {
 
 	c.ActorSystem.Logger().Debug("start cluster member")
@@ -83,6 +88,7 @@ func (t *Provider) StartMember(c *cluster.Cluster) error {
 	return nil
 }
 
+// StartClient starts the provider in client mode without registering services.
 func (t *Provider) StartClient(cluster *cluster.Cluster) error {
 	t.memberList = cluster.MemberList
 	t.id = cluster.ActorSystem.ID
@@ -91,6 +97,7 @@ func (t *Provider) StartClient(cluster *cluster.Cluster) error {
 	return nil
 }
 
+// Shutdown stops the provider and deregisters its service.
 func (t *Provider) Shutdown(_ bool) error {
 	t.cluster.Logger().Debug("Unregistering service", slog.String("service", t.id))
 	if t.ttlReportTicker != nil {
@@ -130,6 +137,7 @@ func (t *Provider) startTtlReport() {
 	}()
 }
 
+// InMemAgent is a lightweight service registry used for testing.
 type InMemAgent struct {
 	services     map[string]AgentServiceStatus
 	servicesLock *sync.RWMutex
@@ -138,6 +146,7 @@ type InMemAgent struct {
 	statusUpdateHandlersLock *sync.RWMutex
 }
 
+// NewInMemAgent returns a new in-memory agent.
 func NewInMemAgent() *InMemAgent {
 	return &InMemAgent{
 		services:                 make(map[string]AgentServiceStatus),
@@ -202,6 +211,7 @@ func (m *InMemAgent) onStatusUpdate() {
 	}
 }
 
+// AgentServiceStatus contains metadata about a registered service.
 type AgentServiceStatus struct {
 	ID    string
 	TTL   time.Time // last alive time
@@ -221,6 +231,7 @@ func NewAgentServiceStatus(id string, host string, port int, kinds []string) Age
 	}
 }
 
+// Alive reports whether the service TTL has not expired.
 func (a AgentServiceStatus) Alive() bool {
 	return time.Now().Sub(a.TTL) <= (time.Second * 5)
 }

--- a/cluster/clusterproviders/zk/config.go
+++ b/cluster/clusterproviders/zk/config.go
@@ -7,6 +7,7 @@ import (
 
 const baseKey = `/protoactor`
 
+// Option configures the ZooKeeper provider.
 type Option func(*config)
 
 // WithAuth set zk auth
@@ -35,12 +36,14 @@ func WithSessionTimeout(tm time.Duration) Option {
 }
 
 // WithRoleChangedListener triggered on self role changed
+// WithRoleChangedListener registers a callback invoked when the node's role changes.
 func WithRoleChangedListener(l RoleChangedListener) Option {
 	return func(o *config) {
 		o.RoleChanged = l
 	}
 }
 
+// WithRoleChangedFunc registers a function to be called on role changes.
 func WithRoleChangedFunc(f OnRoleChangedFunc) Option {
 	return func(o *config) {
 		o.RoleChanged = f
@@ -62,12 +65,15 @@ func (za authConfig) isEmpty() bool {
 	return za.Scheme == "" && za.Credential == ""
 }
 
+// RoleChangedListener is notified whenever the node's leadership role changes.
 type RoleChangedListener interface {
 	OnRoleChanged(RoleType)
 }
 
+// OnRoleChangedFunc is an adapter to allow the use of ordinary functions as listeners.
 type OnRoleChangedFunc func(RoleType)
 
+// OnRoleChanged calls f(rt).
 func (fn OnRoleChangedFunc) OnRoleChanged(rt RoleType) {
 	fn(rt)
 }

--- a/cluster/clusterproviders/zk/node.go
+++ b/cluster/clusterproviders/zk/node.go
@@ -12,6 +12,7 @@ const (
 	metaKeySeq = "seq"
 )
 
+// Node represents a cluster member stored in ZooKeeper.
 type Node struct {
 	ID      string            `json:"id"`
 	Name    string            `json:"name"`
@@ -23,6 +24,7 @@ type Node struct {
 	Alive   bool              `json:"alive"`
 }
 
+// NewNode constructs a new Node instance.
 func NewNode(name, host string, port int, kinds []string) *Node {
 	return &Node{
 		ID:      name,
@@ -36,6 +38,7 @@ func NewNode(name, host string, port int, kinds []string) *Node {
 	}
 }
 
+// GetAddress returns the host and port for the node.
 func (n *Node) GetAddress() (host string, port int) {
 	host = n.Host
 	port = n.Port
@@ -45,11 +48,13 @@ func (n *Node) GetAddress() (host string, port int) {
 	return
 }
 
+// GetAddressString returns a "host:port" string for the node.
 func (n *Node) GetAddressString() string {
 	h, p := n.GetAddress()
 	return fmt.Sprintf("%v:%v", h, p)
 }
 
+// Equal compares two nodes by ID.
 func (n *Node) Equal(other *Node) bool {
 	if n == nil || other == nil {
 		return false
@@ -60,6 +65,7 @@ func (n *Node) Equal(other *Node) bool {
 	return n.ID == other.ID
 }
 
+// GetMeta returns a metadata value by name.
 func (n *Node) GetMeta(name string) (string, bool) {
 	if n.Meta == nil {
 		return "", false
@@ -68,6 +74,7 @@ func (n *Node) GetMeta(name string) (string, bool) {
 	return val, ok
 }
 
+// GetSeq returns the sequence number from metadata.
 func (n *Node) GetSeq() int {
 	if seqStr, ok := n.GetMeta(metaKeySeq); ok {
 		return strToInt(seqStr)
@@ -75,6 +82,7 @@ func (n *Node) GetSeq() int {
 	return 0
 }
 
+// MemberStatus converts the node into a cluster.Member description.
 func (n *Node) MemberStatus() *cluster.Member {
 	host, port := n.GetAddress()
 	kinds := n.Kinds
@@ -89,6 +97,7 @@ func (n *Node) MemberStatus() *cluster.Member {
 	}
 }
 
+// SetMeta sets a metadata value.
 func (n *Node) SetMeta(name string, val string) {
 	if n.Meta == nil {
 		n.Meta = map[string]string{}
@@ -96,6 +105,7 @@ func (n *Node) SetMeta(name string, val string) {
 	n.Meta[name] = val
 }
 
+// Serialize encodes the node to JSON.
 func (n *Node) Serialize() ([]byte, error) {
 	data, err := json.Marshal(n)
 	if err != nil {
@@ -104,6 +114,7 @@ func (n *Node) Serialize() ([]byte, error) {
 	return data, nil
 }
 
+// Deserialize populates the node from JSON data.
 func (n *Node) Deserialize(data []byte) error {
 	return json.Unmarshal(data, n)
 }

--- a/cluster/clusterproviders/zk/singleton.go
+++ b/cluster/clusterproviders/zk/singleton.go
@@ -6,6 +6,7 @@ import (
 	"github.com/asynkron/protoactor-go/actor"
 )
 
+// SingletonScheduler manages actors that should only run on the leader node.
 type SingletonScheduler struct {
 	sync.Mutex
 	root  *actor.RootContext
@@ -13,10 +14,12 @@ type SingletonScheduler struct {
 	pids  []*actor.PID
 }
 
+// NewSingletonScheduler creates a new scheduler bound to the given root context.
 func NewSingletonScheduler(rc *actor.RootContext) *SingletonScheduler {
 	return &SingletonScheduler{root: rc}
 }
 
+// FromFunc registers an actor function to run when the node becomes leader.
 func (s *SingletonScheduler) FromFunc(f actor.ReceiveFunc) *SingletonScheduler {
 	s.Lock()
 	defer s.Unlock()
@@ -24,6 +27,7 @@ func (s *SingletonScheduler) FromFunc(f actor.ReceiveFunc) *SingletonScheduler {
 	return s
 }
 
+// FromProducer registers an actor producer to run when the node becomes leader.
 func (s *SingletonScheduler) FromProducer(f actor.Producer) *SingletonScheduler {
 	s.Lock()
 	defer s.Unlock()
@@ -31,6 +35,7 @@ func (s *SingletonScheduler) FromProducer(f actor.Producer) *SingletonScheduler 
 	return s
 }
 
+// OnRoleChanged reacts to leadership changes and spawns or poisons actors accordingly.
 func (s *SingletonScheduler) OnRoleChanged(rt RoleType) {
 
 	s.Lock()

--- a/cluster/clusterproviders/zk/zk_conn.go
+++ b/cluster/clusterproviders/zk/zk_conn.go
@@ -87,6 +87,7 @@ func newZkOptions(opts ...zkConnOpt) *zkoption {
 
 type zkConnOpt func(*zkoption)
 
+// WithEventCallback sets a callback for ZooKeeper connection events.
 func WithEventCallback(cb zk.EventCallback) zkConnOpt {
 	return func(o *zkoption) {
 		o.ecb = cb

--- a/cluster/clusterproviders/zk/zk_provider.go
+++ b/cluster/clusterproviders/zk/zk_provider.go
@@ -15,10 +15,13 @@ import (
 
 var _ cluster.ClusterProvider = new(Provider)
 
+// RoleType describes the leadership role of a node in the cluster.
 type RoleType int
 
 const (
+	// Follower indicates the node is not the leader.
 	Follower RoleType = iota
+	// Leader indicates the node currently holds leadership.
 	Leader
 )
 
@@ -29,6 +32,7 @@ func (r RoleType) String() string {
 	return "FOLLOWER"
 }
 
+// Provider implements a ZooKeeper-backed cluster provider.
 type Provider struct {
 	cluster             *cluster.Cluster
 	baseKey             string
@@ -47,7 +51,7 @@ type Provider struct {
 	roleChangedChan     chan RoleType
 }
 
-// New zk cluster provider with config
+// New creates a ZooKeeper cluster provider with the given options.
 func New(endpoints []string, opts ...Option) (*Provider, error) {
 	zkCfg := defaultConfig()
 	withEndpoints(endpoints)(zkCfg)
@@ -83,6 +87,7 @@ func New(endpoints []string, opts ...Option) (*Provider, error) {
 	return p, nil
 }
 
+// IsLeader reports whether this node currently has leadership.
 func (p *Provider) IsLeader() bool {
 	return p.role == Leader
 }
@@ -109,6 +114,7 @@ func (p *Provider) init(c *cluster.Cluster) error {
 	return nil
 }
 
+// StartMember registers the node and begins watching ZooKeeper for changes.
 func (p *Provider) StartMember(c *cluster.Cluster) error {
 	if err := p.init(c); err != nil {
 		p.cluster.Logger().Error("init fail " + err.Error())
@@ -139,6 +145,7 @@ func (p *Provider) StartMember(c *cluster.Cluster) error {
 	return nil
 }
 
+// StartClient initializes the provider without registering the node.
 func (p *Provider) StartClient(c *cluster.Cluster) error {
 	if err := p.init(c); err != nil {
 		return err
@@ -155,6 +162,7 @@ func (p *Provider) StartClient(c *cluster.Cluster) error {
 	return nil
 }
 
+// Shutdown deregisters the node and stops background processing.
 func (p *Provider) Shutdown(graceful bool) error {
 	p.shutdown = true
 	if !p.deregistered {

--- a/cluster/identitylookup/disthash/identity_lookup.go
+++ b/cluster/identitylookup/disthash/identity_lookup.go
@@ -6,14 +6,17 @@ import (
 	"github.com/asynkron/protoactor-go/cluster"
 )
 
+// IdentityLookup resolves cluster identities to actor PIDs using a partition manager.
 type IdentityLookup struct {
 	partitionManager *Manager
 }
 
+// Get returns the PID for the given cluster identity if it exists.
 func (p *IdentityLookup) Get(clusterIdentity *cluster.ClusterIdentity) *actor.PID {
 	return p.partitionManager.Get(clusterIdentity)
 }
 
+// RemovePid removes a PID from the cluster identity registry.
 func (p *IdentityLookup) RemovePid(clusterIdentity *cluster.ClusterIdentity, pid *actor.PID) {
 	activationTerminated := &cluster.ActivationTerminated{
 		Pid:             pid,
@@ -22,15 +25,18 @@ func (p *IdentityLookup) RemovePid(clusterIdentity *cluster.ClusterIdentity, pid
 	p.partitionManager.cluster.MemberList.BroadcastEvent(activationTerminated, true)
 }
 
+// Setup initializes the identity lookup for the given cluster.
 func (p *IdentityLookup) Setup(cluster *cluster.Cluster, kinds []string, isClient bool) {
 	p.partitionManager = newPartitionManager(cluster)
 	p.partitionManager.Start()
 }
 
+// Shutdown stops the underlying partition manager.
 func (p *IdentityLookup) Shutdown() {
 	p.partitionManager.Stop()
 }
 
+// New creates a new distributed hash identity lookup implementation.
 func New() cluster.IdentityLookup {
 	return &IdentityLookup{}
 }

--- a/cluster/identitylookup/disthash/manager.go
+++ b/cluster/identitylookup/disthash/manager.go
@@ -10,9 +10,11 @@ import (
 )
 
 const (
+	// PartitionActivatorActorName is the name used for the partition activator actor.
 	PartitionActivatorActorName = "partition-activator"
 )
 
+// Manager coordinates partition ownership and routing for virtual actors.
 type Manager struct {
 	cluster        *clustering.Cluster
 	topologySub    *eventstream.Subscription
@@ -28,6 +30,7 @@ func newPartitionManager(c *clustering.Cluster) *Manager {
 	}
 }
 
+// Start initializes the manager and begins listening for topology changes.
 func (pm *Manager) Start() {
 	pm.cluster.Logger().Info("Started partition manager")
 	system := pm.cluster.ActorSystem
@@ -44,6 +47,7 @@ func (pm *Manager) Start() {
 		})
 }
 
+// Stop terminates the placement actor and unsubscribes from topology events.
 func (pm *Manager) Stop() {
 	system := pm.cluster.ActorSystem
 	system.EventStream.Unsubscribe(pm.topologySub)
@@ -56,6 +60,7 @@ func (pm *Manager) Stop() {
 	pm.cluster.Logger().Info("Stopped PartitionManager")
 }
 
+// PidOfActivatorActor returns the PID of the partition activator on the given node.
 func (pm *Manager) PidOfActivatorActor(addr string) *actor.PID {
 	return actor.NewPID(addr, PartitionActivatorActorName)
 }
@@ -75,6 +80,7 @@ func (pm *Manager) onClusterTopology(tplg *clustering.ClusterTopology) {
 	pm.cluster.ActorSystem.Root.Send(pm.placementActor, tplg)
 }
 
+// Get resolves the PID responsible for the given cluster identity.
 func (pm *Manager) Get(identity *clustering.ClusterIdentity) *actor.PID {
 	pm.rdvMutex.RLock()
 	defer pm.rdvMutex.RUnlock()

--- a/cluster/identitylookup/disthash/placement_actor.go
+++ b/cluster/identitylookup/disthash/placement_actor.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+// GrainMeta tracks the PID associated with a cluster identity.
 type GrainMeta struct {
 	ID  *clustering.ClusterIdentity
 	PID *actor.PID

--- a/cluster/metrics/cluster_metrics.go
+++ b/cluster/metrics/cluster_metrics.go
@@ -42,6 +42,7 @@ func (g *observableGauge) Set(v int64) {
 	g.mu.Unlock()
 }
 
+// ClusterMetrics exposes OpenTelemetry instruments used to record cluster statistics.
 type ClusterMetrics struct {
 	ClusterActorSpawnDuration metric.Float64Histogram
 	ClusterRequestDuration    metric.Float64Histogram
@@ -51,6 +52,7 @@ type ClusterMetrics struct {
 	ClusterMembersCount       *observableGauge
 }
 
+// NewClusterMetrics creates a new metrics container wired to the given logger.
 func NewClusterMetrics(logger *slog.Logger) *ClusterMetrics {
 	meter := otel.Meter(metrics.LibName)
 	m := &ClusterMetrics{}


### PR DESCRIPTION
## Summary
- document cluster test provider and identity lookup types
- add comments for etcd and zookeeper provider internals
- tidy cluster test utilities with explanatory comments

## Testing
- `revive -formatter friendly ./cluster/...`
- `go test ./cluster/...` *(fails: dial tcp 127.0.0.1:8500: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689c2e8e5a50832897d2f1443b90fed9