### PR TITLE
Introduce Future interface for protoactor-go

### DIFF
--- a/actor/actor_context.go
+++ b/actor/actor_context.go
@@ -265,14 +265,15 @@ func (ctx *actorContext) Forward(pid *PID) {
 	ctx.sendUserMessage(pid, ctx.messageOrEnvelope)
 }
 
-func (ctx *actorContext) ReenterAfter(f *Future, cont func(res interface{}, err error)) {
+func (ctx *actorContext) ReenterAfter(f Future, cont func(res interface{}, err error)) {
+	concrete := f.(*future)
 	wrapper := func() {
-		cont(f.result, f.err)
+		cont(concrete.result, concrete.err)
 	}
 
 	message := ctx.messageOrEnvelope
 	// invoke the callback when the future completes
-	f.continueWith(func(res interface{}, err error) {
+	concrete.continueWith(func(res interface{}, err error) {
 		// send the wrapped callback as a continuation message to self
 		ctx.self.sendSystemMessage(ctx.actorSystem, &continuation{
 			f:       wrapper,
@@ -335,7 +336,7 @@ func (ctx *actorContext) RequestWithCustomSender(pid *PID, message interface{}, 
 	ctx.sendUserMessage(pid, env)
 }
 
-func (ctx *actorContext) RequestFuture(pid *PID, message interface{}, timeout time.Duration) *Future {
+func (ctx *actorContext) RequestFuture(pid *PID, message interface{}, timeout time.Duration) Future {
 	future := NewFuture(ctx.actorSystem, timeout)
 	env := &MessageEnvelope{
 		Header:  nil,
@@ -450,8 +451,8 @@ func (ctx *actorContext) Stop(pid *PID) {
 }
 
 // StopFuture will stop actor immediately regardless of existing user messages in mailbox, and return its future.
-func (ctx *actorContext) StopFuture(pid *PID) *Future {
-	future := NewFuture(ctx.actorSystem, 10*time.Second)
+func (ctx *actorContext) StopFuture(pid *PID) Future {
+	future := newFuture(ctx.actorSystem, 10*time.Second)
 
 	pid.sendSystemMessage(ctx.actorSystem, &Watch{Watcher: future.pid})
 	ctx.Stop(pid)
@@ -465,8 +466,8 @@ func (ctx *actorContext) Poison(pid *PID) {
 }
 
 // PoisonFuture will tell actor to stop after processing current user messages in mailbox, and return its future.
-func (ctx *actorContext) PoisonFuture(pid *PID) *Future {
-	future := NewFuture(ctx.actorSystem, 10*time.Second)
+func (ctx *actorContext) PoisonFuture(pid *PID) Future {
+	future := newFuture(ctx.actorSystem, 10*time.Second)
 
 	pid.sendSystemMessage(ctx.actorSystem, &Watch{Watcher: future.pid})
 	ctx.Poison(pid)

--- a/actor/common_test.go
+++ b/actor/common_test.go
@@ -102,7 +102,7 @@ func (m *mockContext) Forward(_ *PID) {
 	m.Called()
 }
 
-func (m *mockContext) ReenterAfter(f *Future, cont func(res interface{}, err error)) {
+func (m *mockContext) ReenterAfter(f Future, cont func(res interface{}, err error)) {
 	m.Called(f, cont)
 }
 
@@ -159,10 +159,10 @@ func (m *mockContext) RequestWithCustomSender(pid *PID, message interface{}, sen
 	p.SendUserMessage(pid, env)
 }
 
-func (m *mockContext) RequestFuture(_ *PID, _ interface{}, _ time.Duration) *Future {
+func (m *mockContext) RequestFuture(_ *PID, _ interface{}, _ time.Duration) Future {
 	args := m.Called()
 
-	return args.Get(0).(*Future)
+	return args.Get(0).(Future)
 }
 
 //

--- a/actor/context.go
+++ b/actor/context.go
@@ -97,7 +97,7 @@ type basePart interface {
 	// Forward forwards current message to the given PID
 	Forward(pid *PID)
 
-	ReenterAfter(f *Future, continuation func(res interface{}, err error))
+	ReenterAfter(f Future, continuation func(res interface{}, err error))
 
 	// Capture captures the current MessageEnvelope for the context.
 	// Use the returned CapturedContext to reprocess messages later.
@@ -129,7 +129,7 @@ type senderPart interface {
 	RequestWithCustomSender(pid *PID, message interface{}, sender *PID)
 
 	// RequestFuture sends a message to a given PID and returns a Future
-	RequestFuture(pid *PID, message interface{}, timeout time.Duration) *Future
+	RequestFuture(pid *PID, message interface{}, timeout time.Duration) Future
 }
 
 type receiverPart interface {
@@ -156,11 +156,11 @@ type stopperPart interface {
 	Stop(pid *PID)
 
 	// StopFuture will stop actor immediately regardless of existing user messages in mailbox, and return its future.
-	StopFuture(pid *PID) *Future
+	StopFuture(pid *PID) Future
 
 	// Poison will tell actor to stop after processing current user messages in mailbox.
 	Poison(pid *PID)
 
 	// PoisonFuture will tell actor to stop after processing current user messages in mailbox, and return its future.
-	PoisonFuture(pid *PID) *Future
+	PoisonFuture(pid *PID) Future
 }

--- a/actor/future.go
+++ b/actor/future.go
@@ -19,9 +19,21 @@ var ErrTimeout = errors.New("future: timeout")
 // ErrDeadLetter is meaning you request to a unreachable PID.
 var ErrDeadLetter = errors.New("future: dead letter")
 
-// NewFuture creates and returns a new actor.Future with a timeout of duration d.
-func NewFuture(actorSystem *ActorSystem, d time.Duration) *Future {
-	ref := &futureProcess{Future{actorSystem: actorSystem, cond: sync.NewCond(&sync.Mutex{})}}
+// Future defines the public interface for future responses.
+type Future interface {
+	// PID to the backing actor for the Future result.
+	PID() *PID
+	// PipeTo forwards the result or error of the future to the specified PIDs.
+	PipeTo(pids ...*PID)
+	// Result waits for the future to resolve and returns the result or error.
+	Result() (interface{}, error)
+	// Wait blocks until the future resolves and returns the error, if any.
+	Wait() error
+}
+
+// newFuture creates and returns a new future with a timeout of duration d.
+func newFuture(actorSystem *ActorSystem, d time.Duration) *future {
+	ref := &futureProcess{future{actorSystem: actorSystem, cond: sync.NewCond(&sync.Mutex{})}}
 	id := actorSystem.ProcessRegistry.NextId()
 
 	pid, ok := actorSystem.ProcessRegistry.Add(ref, "future"+id)
@@ -59,10 +71,15 @@ func NewFuture(actorSystem *ActorSystem, d time.Duration) *Future {
 		atomic.StorePointer((*unsafe.Pointer)(unsafe.Pointer(&ref.t)), unsafe.Pointer(tp))
 	}
 
-	return &ref.Future
+	return &ref.future
 }
 
-type Future struct {
+// NewFuture creates and returns a new Future with a timeout of duration d.
+func NewFuture(actorSystem *ActorSystem, d time.Duration) Future {
+	return newFuture(actorSystem, d)
+}
+
+type future struct {
 	actorSystem *ActorSystem
 	pid         *PID
 	cond        *sync.Cond
@@ -76,12 +93,12 @@ type Future struct {
 }
 
 // PID to the backing actor for the Future result.
-func (f *Future) PID() *PID {
+func (f *future) PID() *PID {
 	return f.pid
 }
 
 // PipeTo forwards the result or error of the future to the specified pids.
-func (f *Future) PipeTo(pids ...*PID) {
+func (f *future) PipeTo(pids ...*PID) {
 	f.cond.L.Lock()
 	f.pipes = append(f.pipes, pids...)
 	// for an already completed future, force push the result to targets.
@@ -91,7 +108,7 @@ func (f *Future) PipeTo(pids ...*PID) {
 	f.cond.L.Unlock()
 }
 
-func (f *Future) sendToPipes() {
+func (f *future) sendToPipes() {
 	if f.pipes == nil {
 		return
 	}
@@ -110,7 +127,7 @@ func (f *Future) sendToPipes() {
 	f.pipes = nil
 }
 
-func (f *Future) wait() {
+func (f *future) wait() {
 	f.cond.L.Lock()
 	for !f.done {
 		f.cond.Wait()
@@ -119,19 +136,19 @@ func (f *Future) wait() {
 }
 
 // Result waits for the future to resolve.
-func (f *Future) Result() (interface{}, error) {
+func (f *future) Result() (interface{}, error) {
 	f.wait()
 
 	return f.result, f.err
 }
 
-func (f *Future) Wait() error {
+func (f *future) Wait() error {
 	f.wait()
 
 	return f.err
 }
 
-func (f *Future) continueWith(continuation func(res interface{}, err error)) {
+func (f *future) continueWith(continuation func(res interface{}, err error)) {
 	f.cond.L.Lock()
 	defer f.cond.L.Unlock() // use defer as the continuation co
 	// uld blow up
@@ -144,7 +161,7 @@ func (f *Future) continueWith(continuation func(res interface{}, err error)) {
 
 // futureProcess is a struct carrying a response PID and a channel where the response is placed.
 type futureProcess struct {
-	Future
+	future
 }
 
 var _ Process = &futureProcess{}
@@ -219,7 +236,7 @@ func (ref *futureProcess) Stop(pid *PID) {
 // TODO: we could replace "pipes" with this
 // instead of pushing PIDs to pipes, we could push wrapper funcs that tells the pid
 // as a completion, that would unify the model.
-func (f *Future) runCompletions() {
+func (f *future) runCompletions() {
 	if f.completions == nil {
 		return
 	}

--- a/actor/future_test.go
+++ b/actor/future_test.go
@@ -27,11 +27,11 @@ func TestFuture_PipeTo_Message(t *testing.T) {
 	f.PipeTo(a2)
 	f.PipeTo(a3)
 
-	ref, _ := system.ProcessRegistry.Get(f.pid)
+	ref, _ := system.ProcessRegistry.Get(f.(*future).pid)
 	assert.IsType(t, &futureProcess{}, ref)
 	fp, _ := ref.(*futureProcess)
 
-	fp.SendUserMessage(f.pid, "hello")
+	fp.SendUserMessage(f.(*future).pid, "hello")
 	p1.AssertExpectations(t)
 	p2.AssertExpectations(t)
 	p3.AssertExpectations(t)
@@ -53,7 +53,7 @@ func TestFuture_PipeTo_TimeoutSendsError(t *testing.T) {
 	p3.On("SendUserMessage", a3, ErrTimeout)
 
 	f := NewFuture(system, 10*time.Millisecond)
-	ref, _ := system.ProcessRegistry.Get(f.pid)
+	ref, _ := system.ProcessRegistry.Get(f.(*future).pid)
 
 	f.PipeTo(a1)
 	f.PipeTo(a2)
@@ -84,7 +84,7 @@ func TestNewFuture_TimeoutNoRace(t *testing.T) {
 	_, _ = future.Result()
 }
 
-func assertFutureSuccess(future *Future, t *testing.T) interface{} {
+func assertFutureSuccess(future Future, t *testing.T) interface{} {
 	res, err := future.Result()
 	assert.NoError(t, err, "timed out")
 	return res

--- a/actor/root_context.go
+++ b/actor/root_context.go
@@ -127,7 +127,7 @@ func (rc *RootContext) RequestWithCustomSender(pid *PID, message interface{}, se
 }
 
 // RequestFuture sends a message to a given PID and returns a Future.
-func (rc *RootContext) RequestFuture(pid *PID, message interface{}, timeout time.Duration) *Future {
+func (rc *RootContext) RequestFuture(pid *PID, message interface{}, timeout time.Duration) Future {
 	future := NewFuture(rc.actorSystem, timeout)
 	env := &MessageEnvelope{
 		Header:  nil,
@@ -201,8 +201,8 @@ func (rc *RootContext) Stop(pid *PID) {
 }
 
 // StopFuture will stop actor immediately regardless of existing user messages in mailbox, and return its future.
-func (rc *RootContext) StopFuture(pid *PID) *Future {
-	future := NewFuture(rc.actorSystem, 10*time.Second)
+func (rc *RootContext) StopFuture(pid *PID) Future {
+	future := newFuture(rc.actorSystem, 10*time.Second)
 
 	pid.sendSystemMessage(rc.actorSystem, &Watch{Watcher: future.pid})
 	rc.Stop(pid)
@@ -216,8 +216,8 @@ func (rc *RootContext) Poison(pid *PID) {
 }
 
 // PoisonFuture will tell actor to stop after processing current user messages in mailbox, and return its future.
-func (rc *RootContext) PoisonFuture(pid *PID) *Future {
-	future := NewFuture(rc.actorSystem, 10*time.Second)
+func (rc *RootContext) PoisonFuture(pid *PID) Future {
+	future := newFuture(rc.actorSystem, 10*time.Second)
 
 	pid.sendSystemMessage(rc.actorSystem, &Watch{Watcher: future.pid})
 	rc.Poison(pid)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -190,7 +190,7 @@ func (c *Cluster) Request(identity string, kind string, message interface{}, opt
 	return c.context.Request(identity, kind, message, option...)
 }
 
-func (c *Cluster) RequestFuture(identity string, kind string, message interface{}, option ...GrainCallOption) (*actor.Future, error) {
+func (c *Cluster) RequestFuture(identity string, kind string, message interface{}, option ...GrainCallOption) (actor.Future, error) {
 	return c.context.RequestFuture(identity, kind, message, option...)
 }
 

--- a/cluster/context.go
+++ b/cluster/context.go
@@ -5,5 +5,5 @@ import "github.com/asynkron/protoactor-go/actor"
 // Context is an interface any cluster context needs to implement
 type Context interface {
 	Request(identity string, kind string, message interface{}, opts ...GrainCallOption) (interface{}, error)
-	RequestFuture(identity string, kind string, message interface{}, opts ...GrainCallOption) (*actor.Future, error)
+	RequestFuture(identity string, kind string, message interface{}, opts ...GrainCallOption) (actor.Future, error)
 }

--- a/cluster/default_context.go
+++ b/cluster/default_context.go
@@ -146,7 +146,7 @@ selectloop:
 	return resp, err
 }
 
-func (dcc *DefaultContext) RequestFuture(identity string, kind string, message interface{}, opts ...GrainCallOption) (*actor.Future, error) {
+func (dcc *DefaultContext) RequestFuture(identity string, kind string, message interface{}, opts ...GrainCallOption) (actor.Future, error) {
 	var counter int
 	callConfig := DefaultGrainCallConfig(dcc.cluster)
 	for _, o := range opts {

--- a/cluster/identity_storage_lookup.go
+++ b/cluster/identity_storage_lookup.go
@@ -49,7 +49,7 @@ func (id *IdentityStorageLookup) Get(clusterIdentity *ClusterIdentity) *actor.PI
 	timeout := 5 * time.Second
 
 	res, _ := id.system.Root.RequestFuture(id.router, msg, timeout).Result()
-	response := res.(*actor.Future)
+	response := res.(actor.Future)
 
 	return response.PID()
 }

--- a/cluster/identitylookup/disthash/placement_actor.go
+++ b/cluster/identitylookup/disthash/placement_actor.go
@@ -70,7 +70,7 @@ func (p *placementActor) onTerminated(msg *actor.Terminated) {
 }
 
 func (p *placementActor) onStopping(ctx actor.Context) {
-	futures := make(map[string]*actor.Future, len(p.actors))
+	futures := make(map[string]actor.Future, len(p.actors))
 
 	for key, meta := range p.actors {
 		futures[key] = ctx.PoisonFuture(meta.PID)

--- a/cluster/pubsub_delivery.go
+++ b/cluster/pubsub_delivery.go
@@ -30,7 +30,7 @@ func (p *PubSubMemberDeliveryActor) Receive(c actor.Context) {
 		invalidDeliveries := make([]*SubscriberDeliveryReport, 0, len(siList))
 
 		type futureWithIdentity struct {
-			future   *actor.Future
+			future   actor.Future
 			identity *SubscriberIdentity
 		}
 		futureList := make([]futureWithIdentity, 0, len(siList))
@@ -81,7 +81,7 @@ func (p *PubSubMemberDeliveryActor) Receive(c actor.Context) {
 }
 
 // DeliverBatch delivers PubSubAutoRespondBatch to SubscriberIdentity.
-func (p *PubSubMemberDeliveryActor) DeliverBatch(c actor.Context, batch *PubSubAutoRespondBatch, s *SubscriberIdentity) *actor.Future {
+func (p *PubSubMemberDeliveryActor) DeliverBatch(c actor.Context, batch *PubSubAutoRespondBatch, s *SubscriberIdentity) actor.Future {
 	if pid := s.GetPid(); pid != nil {
 		return p.DeliverToPid(c, batch, pid)
 	}
@@ -92,12 +92,12 @@ func (p *PubSubMemberDeliveryActor) DeliverBatch(c actor.Context, batch *PubSubA
 }
 
 // DeliverToPid delivers PubSubAutoRespondBatch to PID.
-func (p *PubSubMemberDeliveryActor) DeliverToPid(c actor.Context, batch *PubSubAutoRespondBatch, pid *actor.PID) *actor.Future {
+func (p *PubSubMemberDeliveryActor) DeliverToPid(c actor.Context, batch *PubSubAutoRespondBatch, pid *actor.PID) actor.Future {
 	return c.RequestFuture(pid, batch, p.subscriberTimeout)
 }
 
 // DeliverToClusterIdentity delivers PubSubAutoRespondBatch to ClusterIdentity.
-func (p *PubSubMemberDeliveryActor) DeliverToClusterIdentity(c actor.Context, batch *PubSubAutoRespondBatch, ci *ClusterIdentity) *actor.Future {
+func (p *PubSubMemberDeliveryActor) DeliverToClusterIdentity(c actor.Context, batch *PubSubAutoRespondBatch, ci *ClusterIdentity) actor.Future {
 	cluster := GetCluster(c.ActorSystem())
 	// deliver to virtual actor
 	// delivery should always be possible, since a virtual actor always exists

--- a/examples/cluster-error-response/protos_grain.pb.go
+++ b/examples/cluster-error-response/protos_grain.pb.go
@@ -84,7 +84,7 @@ type HelloGrainClient struct {
 }
 
 // ReenterableFuture return a future for the execution of Reenterable on the cluster
-func (g *HelloGrainClient) ReenterableFuture(r *ReenterableRequest, opts ...cluster.GrainCallOption) (*actor.Future, error) {
+func (g *HelloGrainClient) ReenterableFuture(r *ReenterableRequest, opts ...cluster.GrainCallOption) (actor.Future, error) {
 	bytes, err := proto.Marshal(r)
 	if err != nil {
 		return nil, err

--- a/examples/cluster-reentrancy/hello_grain.pb.go
+++ b/examples/cluster-reentrancy/hello_grain.pb.go
@@ -72,7 +72,7 @@ type HelloGrainClient struct {
 }
 
 // InvokeServiceFuture return a future for the execution of InvokeService on the cluster
-func (g *HelloGrainClient) InvokeServiceFuture(r *InvokeServiceRequest, opts ...cluster.GrainCallOption) (*actor.Future, error) {
+func (g *HelloGrainClient) InvokeServiceFuture(r *InvokeServiceRequest, opts ...cluster.GrainCallOption) (actor.Future, error) {
 	bytes, err := proto.Marshal(r)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func (g *HelloGrainClient) InvokeService(r *InvokeServiceRequest, opts ...cluste
 }
 
 // DoWorkFuture return a future for the execution of DoWork on the cluster
-func (g *HelloGrainClient) DoWorkFuture(r *DoWorkRequest, opts ...cluster.GrainCallOption) (*actor.Future, error) {
+func (g *HelloGrainClient) DoWorkFuture(r *DoWorkRequest, opts ...cluster.GrainCallOption) (actor.Future, error) {
 	bytes, err := proto.Marshal(r)
 	if err != nil {
 		return nil, err

--- a/protobuf/protoc-gen-go-grain/templates/grain.tmpl
+++ b/protobuf/protoc-gen-go-grain/templates/grain.tmpl
@@ -62,19 +62,19 @@ type {{ $service.Name }}GrainClient struct {
 {{ range $method := .Methods}}
 {{ if $method.Options.Future -}}
 // {{ $method.Name }}Future return a future for the execution of {{ $method.Name }} on the cluster
-func (g *{{ $service.Name }}GrainClient) {{ $method.Name }}Future(r *{{ $method.Input }}, opts ...cluster.GrainCallOption) (*actor.Future, error) {
+func (g *{{ $service.Name }}GrainClient) {{ $method.Name }}Future(r *{{ $method.Input }}, opts ...cluster.GrainCallOption) (actor.Future, error) {
 	bytes, err := proto.Marshal(r)
 	if err != nil {
 		return nil, err
 	}
 
 	reqMsg := &cluster.GrainRequest{MethodIndex: {{ $method.Index }}, MessageData: bytes}
-	f, err := g.cluster.RequestFuture(g.Identity, "{{ $service.Name }}", reqMsg, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("error request future: %w", err)
-	}
+        f, err := g.cluster.RequestFuture(g.Identity, "{{ $service.Name }}", reqMsg, opts...)
+        if err != nil {
+                return nil, fmt.Errorf("error request future: %w", err)
+        }
 
-	return f, nil
+        return f, nil
 }
 {{ end }}
 // {{ $method.Name }} requests the execution on to the cluster with CallOptions

--- a/protobuf/protoc-gen-go-grain/test/reenter/hello_grain.pb.go
+++ b/protobuf/protoc-gen-go-grain/test/reenter/hello_grain.pb.go
@@ -99,7 +99,7 @@ func (g *HelloGrainClient) SayHello(r *SayHelloRequest, opts ...cluster.GrainCal
 }
 
 // DoworkFuture return a future for the execution of Dowork on the cluster
-func (g *HelloGrainClient) DoworkFuture(r *DoworkRequest, opts ...cluster.GrainCallOption) (*actor.Future, error) {
+func (g *HelloGrainClient) DoworkFuture(r *DoworkRequest, opts ...cluster.GrainCallOption) (actor.Future, error) {
 	bytes, err := proto.Marshal(r)
 	if err != nil {
 		return nil, err

--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -53,7 +53,7 @@ func (r *Remote) ActivatorForAddress(address string) *actor.PID {
 }
 
 // SpawnFuture spawns a remote actor and returns a Future that completes once the actor is started
-func (r *Remote) SpawnFuture(address, name, kind string, timeout time.Duration) *actor.Future {
+func (r *Remote) SpawnFuture(address, name, kind string, timeout time.Duration) actor.Future {
 	activator := r.ActivatorForAddress(address)
 	f := r.actorSystem.Root.RequestFuture(activator, &ActorPidRequest{
 		Name: name,

--- a/router/common_test.go
+++ b/router/common_test.go
@@ -106,7 +106,7 @@ func (m *mockContext) Forward(pid *actor.PID) {
 	m.Called()
 }
 
-func (m *mockContext) ReenterAfter(f *actor.Future, cont func(res interface{}, err error)) {
+func (m *mockContext) ReenterAfter(f actor.Future, cont func(res interface{}, err error)) {
 	m.Called(f, cont)
 }
 
@@ -161,12 +161,12 @@ func (m *mockContext) RequestWithCustomSender(pid *actor.PID, message interface{
 	p.SendUserMessage(pid, env)
 }
 
-func (m *mockContext) RequestFuture(pid *actor.PID, message interface{}, timeout time.Duration) *actor.Future {
+func (m *mockContext) RequestFuture(pid *actor.PID, message interface{}, timeout time.Duration) actor.Future {
 	args := m.Called()
 	m.Called()
 	p, _ := system.ProcessRegistry.Get(pid)
 	p.SendUserMessage(pid, message)
-	return args.Get(0).(*actor.Future)
+	return args.Get(0).(actor.Future)
 }
 
 //
@@ -204,18 +204,18 @@ func (m *mockContext) Stop(pid *actor.PID) {
 	m.Called(pid)
 }
 
-func (m *mockContext) StopFuture(pid *actor.PID) *actor.Future {
+func (m *mockContext) StopFuture(pid *actor.PID) actor.Future {
 	args := m.Called(pid)
-	return args.Get(0).(*actor.Future)
+	return args.Get(0).(actor.Future)
 }
 
 func (m *mockContext) Poison(pid *actor.PID) {
 	m.Called(pid)
 }
 
-func (m *mockContext) PoisonFuture(pid *actor.PID) *actor.Future {
+func (m *mockContext) PoisonFuture(pid *actor.PID) actor.Future {
 	args := m.Called(pid)
-	return args.Get(0).(*actor.Future)
+	return args.Get(0).(actor.Future)
 }
 
 // mockProcess


### PR DESCRIPTION
## Summary
- define a public `Future` interface and wire existing future implementation to it
- update core contexts and cluster/remote helpers to return the new interface
- adjust tests and generated code to compile with the interface-based future

## Testing
- `go test ./actor -run TestFuture -count=1`
- `go test ./remote -run Test -count=1`
- `go test ./cluster -run Test -count=1`
- `go test ./router -run Test -count=1` *(fails: TestConcurrency timed out)*

------
https://chatgpt.com/codex/tasks/task_e_689c5ff2fb6c8328b73ca80e5a77bf71