### PR TITLE
refactor: reduce topology member logging

### DIFF
--- a/cluster/identitylookup/disthash/manager.go
+++ b/cluster/identitylookup/disthash/manager.go
@@ -5,6 +5,8 @@ import (
 	clustering "github.com/asynkron/protoactor-go/cluster"
 	"github.com/asynkron/protoactor-go/eventstream"
 	"log/slog"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -69,11 +71,16 @@ func (pm *Manager) onClusterTopology(tplg *clustering.ClusterTopology) {
 	pm.rdvMutex.Lock()
 	defer pm.rdvMutex.Unlock()
 
-	pm.cluster.Logger().Info("onClusterTopology", slog.Uint64("topology-hash", tplg.TopologyHash))
-
-	for _, m := range tplg.Members {
-		pm.cluster.Logger().Info("Got member", slog.Any("member", m))
+	// gather member addresses to provide a concise summary log while
+	// keeping detailed member data available at debug level
+	memberAddrs := make([]string, len(tplg.Members))
+	for i, m := range tplg.Members {
+		addr := m.Host + ":" + strconv.Itoa(int(m.Port))
+		pm.cluster.Logger().Debug("Topology member", slog.String("id", m.Id), slog.String("address", addr), slog.String("kinds", strings.Join(m.Kinds, ",")))
+		memberAddrs[i] = addr
 	}
+	// log the overall topology change in a single info log
+	pm.cluster.Logger().Info("onClusterTopology", slog.Uint64("topology-hash", tplg.TopologyHash), slog.Int("member-count", len(memberAddrs)), slog.String("members", strings.Join(memberAddrs, ",")))
 
 	pm.rdv = clustering.NewRendezvous()
 	pm.rdv.UpdateMembers(tplg.Members)


### PR DESCRIPTION
## Summary
- reduce topology member log spam by moving per-node messages to debug
- summarize topology changes in a single info log

## Testing
- `go test ./cluster/identitylookup/disthash`
- `go test ./...` *(fails: Failed to register service to consul, dial tcp 127.0.0.1:8500: connect: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689ca0fcc9c883289420c5d6fb9dee00