### PR TITLE
Log activation errors in distributed hash manager

### DIFF
--- a/cluster/identitylookup/disthash/identity_lookup.go
+++ b/cluster/identitylookup/disthash/identity_lookup.go
@@ -4,6 +4,7 @@ package disthash
 import (
 	"github.com/asynkron/protoactor-go/actor"
 	"github.com/asynkron/protoactor-go/cluster"
+	"log/slog"
 )
 
 // IdentityLookup resolves cluster identities to actor PIDs using a partition manager.
@@ -12,8 +13,13 @@ type IdentityLookup struct {
 }
 
 // Get returns the PID for the given cluster identity if it exists.
+// Errors from the underlying partition manager are logged.
 func (p *IdentityLookup) Get(clusterIdentity *cluster.ClusterIdentity) *actor.PID {
-	return p.partitionManager.Get(clusterIdentity)
+	pid, err := p.partitionManager.Get(clusterIdentity)
+	if err != nil {
+		p.partitionManager.cluster.Logger().Error("Partition manager lookup failed", slog.Any("error", err))
+	}
+	return pid
 }
 
 // RemovePid removes a PID from the cluster identity registry.

--- a/cluster/identitylookup/disthash/manager.go
+++ b/cluster/identitylookup/disthash/manager.go
@@ -1,6 +1,7 @@
 package disthash
 
 import (
+	"fmt"
 	"github.com/asynkron/protoactor-go/actor"
 	clustering "github.com/asynkron/protoactor-go/cluster"
 	"github.com/asynkron/protoactor-go/eventstream"
@@ -81,14 +82,16 @@ func (pm *Manager) onClusterTopology(tplg *clustering.ClusterTopology) {
 }
 
 // Get resolves the PID responsible for the given cluster identity.
-func (pm *Manager) Get(identity *clustering.ClusterIdentity) *actor.PID {
+// It logs unexpected errors and responses for easier troubleshooting.
+// Consider changing the signature to return an error if callers can handle it.
+func (pm *Manager) Get(identity *clustering.ClusterIdentity) (*actor.PID, error) {
 	pm.rdvMutex.RLock()
 	defer pm.rdvMutex.RUnlock()
 
 	ownerAddress := pm.rdv.GetByClusterIdentity(identity)
 
 	if ownerAddress == "" {
-		return nil
+		return nil, nil
 	}
 
 	identityOwnerPid := pm.PidOfActivatorActor(ownerAddress)
@@ -99,11 +102,13 @@ func (pm *Manager) Get(identity *clustering.ClusterIdentity) *actor.PID {
 	future := pm.cluster.ActorSystem.Root.RequestFuture(identityOwnerPid, request, 5*time.Second)
 	res, err := future.Result()
 	if err != nil {
-		return nil
+		pm.cluster.Logger().Error("Activation request failed", slog.Any("error", err))
+		return nil, err
 	}
 	typed, ok := res.(*clustering.ActivationResponse)
 	if !ok {
-		return nil
+		pm.cluster.Logger().Error("Unexpected activation response", slog.Any("response", res))
+		return nil, fmt.Errorf("unexpected activation response of type %T", res)
 	}
-	return typed.Pid
+	return typed.Pid, nil
 }

--- a/cluster/identitylookup/disthash/manager_test.go
+++ b/cluster/identitylookup/disthash/manager_test.go
@@ -55,7 +55,7 @@ func TestManagerConcurrentAccess(t *testing.T) {
 				Identity: "test",
 				Kind:     "test",
 			}
-			_ = manager.Get(identity)
+			_, _ = manager.Get(identity)
 		}
 	}()
 


### PR DESCRIPTION
## Summary
- log errors when activation requests fail or return unexpected responses in distributed hash manager
- surface manager errors to identity lookup for optional logging

## Testing
- `go test ./cluster/identitylookup/disthash -run .`
- `go test ./...` *(fails: connection refused to Consul)*

------
https://chatgpt.com/codex/tasks/task_e_689ca0e91b088328bebe5b0bc4c7c36c