### PR TITLE
Return failed activation for unknown cluster kinds

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -182,6 +182,8 @@ func (c *Cluster) Shutdown(graceful bool) {
 	c.Logger().Info("Stopped Proto.Actor cluster", slog.String("address", address))
 }
 
+// Get resolves the PID for the given identity and kind.
+// It returns nil if the kind is not registered or the activation fails.
 func (c *Cluster) Get(identity string, kind string) *actor.PID {
 	return c.IdentityLookup.Get(NewClusterIdentity(identity, kind))
 }

--- a/cluster/identitylookup/disthash/manager.go
+++ b/cluster/identitylookup/disthash/manager.go
@@ -81,6 +81,7 @@ func (pm *Manager) onClusterTopology(tplg *clustering.ClusterTopology) {
 }
 
 // Get resolves the PID responsible for the given cluster identity.
+// Returns nil if the cluster kind is unknown or activation failed.
 func (pm *Manager) Get(identity *clustering.ClusterIdentity) *actor.PID {
 	pm.rdvMutex.RLock()
 	defer pm.rdvMutex.RUnlock()
@@ -102,7 +103,7 @@ func (pm *Manager) Get(identity *clustering.ClusterIdentity) *actor.PID {
 		return nil
 	}
 	typed, ok := res.(*clustering.ActivationResponse)
-	if !ok {
+	if !ok || typed.Failed {
 		return nil
 	}
 	return typed.Pid

--- a/cluster/identitylookup/disthash/manager_test.go
+++ b/cluster/identitylookup/disthash/manager_test.go
@@ -13,6 +13,28 @@ import (
 	"time"
 )
 
+func TestPlacementActorUnknownKind(t *testing.T) {
+	system := actor.NewActorSystem()
+	provider := test.NewTestProvider(test.NewInMemAgent())
+	lookup := New()
+	config := cluster.Configure("test-cluster", provider, lookup, remote.Configure("127.0.0.1", 0))
+	c := cluster.New(system, config)
+
+	manager := newPartitionManager(c)
+	manager.Start()
+	defer manager.Stop()
+
+	identity := &cluster.ClusterIdentity{Identity: "abc", Kind: "unknown"}
+	req := &cluster.ActivationRequest{ClusterIdentity: identity}
+	future := system.Root.RequestFuture(manager.placementActor, req, time.Second)
+	res, err := future.Result()
+	assert.NoError(t, err)
+	resp, ok := res.(*cluster.ActivationResponse)
+	assert.True(t, ok)
+	assert.True(t, resp.Failed)
+	assert.Nil(t, resp.Pid)
+}
+
 func TestManagerConcurrentAccess(t *testing.T) {
 	system := actor.NewActorSystem()
 	provider := test.NewTestProvider(test.NewInMemAgent())

--- a/cluster/identitylookup/disthash/placement_actor.go
+++ b/cluster/identitylookup/disthash/placement_actor.go
@@ -99,8 +99,8 @@ func (p *placementActor) onActivationRequest(msg *clustering.ActivationRequest, 
 	if clusterKind == nil {
 		ctx.Logger().Error("Unknown cluster kind", slog.String("kind", msg.ClusterIdentity.Kind))
 
-		// TODO: what to do here?
-		ctx.Respond(nil)
+		// Reply with a failed activation so callers can handle the error.
+		ctx.Respond(&clustering.ActivationResponse{Failed: true})
 		return
 	}
 


### PR DESCRIPTION
## Summary
- return a failed `ActivationResponse` when a cluster kind is unknown
- document `Cluster.Get` and manager lookup behavior for unknown kinds
- test placement actor's response to unknown kinds

## Testing
- `go test ./cluster/identitylookup/disthash -count=1`
- `go test ./...` *(fails: Failed to register service to consul)*

------
https://chatgpt.com/codex/tasks/task_e_689ca0f638f08328bcc4b9d818524c67