### PR TITLE
build: compile all packages and examples

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,6 +27,11 @@ jobs:
           cache: true
       - name: start services
         run: docker compose up -d
+      - name: build
+        run: go build ./...
+      - name: build examples
+        run: |
+          find ./examples -name go.mod -execdir sh -c 'go mod tidy && go build ./...' \;
       - name: run testcases
         run: make test2
       - name: benchmark


### PR DESCRIPTION
## Summary
- build the main module to catch compile errors early
- compile every example module to ensure examples keep building

## Testing
- `make test2` *(fails: interrupt)*
- `make vet` *(fails: interrupt)*
- `make lint` *(fails: interrupt)*
- `make bench` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_689cad1d9ca88328abf38d2b668271b2