### PR TITLE
chore: address lint warnings

### DIFF
--- a/actor/actor_context.go
+++ b/actor/actor_context.go
@@ -273,7 +273,7 @@ func (ctx *actorContext) ReenterAfter(f Future, cont func(res interface{}, err e
 
 	message := ctx.messageOrEnvelope
 	// invoke the callback when the future completes
-	concrete.continueWith(func(res interface{}, err error) {
+	concrete.continueWith(func(_ interface{}, _ error) {
 		// send the wrapped callback as a continuation message to self
 		ctx.self.sendSystemMessage(ctx.actorSystem, &continuation{
 			f:       wrapper,
@@ -390,7 +390,7 @@ func (ctx *actorContext) defaultReceive() {
 //
 
 func (ctx *actorContext) Spawn(props *Props) *PID {
-	pid, err := ctx.SpawnNamed(props, ctx.actorSystem.ProcessRegistry.NextId())
+	pid, err := ctx.SpawnNamed(props, ctx.actorSystem.ProcessRegistry.NextID())
 	if err != nil {
 		panic(err)
 	}
@@ -399,7 +399,7 @@ func (ctx *actorContext) Spawn(props *Props) *PID {
 }
 
 func (ctx *actorContext) SpawnPrefix(props *Props, prefix string) *PID {
-	pid, err := ctx.SpawnNamed(props, prefix+ctx.actorSystem.ProcessRegistry.NextId())
+	pid, err := ctx.SpawnNamed(props, prefix+ctx.actorSystem.ProcessRegistry.NextID())
 	if err != nil {
 		panic(err)
 	}
@@ -438,7 +438,7 @@ func (ctx *actorContext) SpawnNamed(props *Props, name string) (*PID, error) {
 // Stop will stop actor immediately regardless of existing user messages in mailbox.
 func (ctx *actorContext) Stop(pid *PID) {
 	if ctx.actorSystem.Config.MetricsEnabled {
-		metricsSystem, ok := ctx.actorSystem.Extensions.Get(extensionId).(*Metrics)
+		metricsSystem, ok := ctx.actorSystem.Extensions.Get(extensionID).(*Metrics)
 		if ok && metricsSystem.Enabled() {
 			_ctx := context.Background()
 			if instruments := metricsSystem.metrics.Get(metrics.InternalActorMetrics); instruments != nil {
@@ -495,7 +495,7 @@ func (ctx *actorContext) InvokeUserMessage(md interface{}) {
 		}
 	}
 
-	systemMetrics, ok := ctx.actorSystem.Extensions.Get(extensionId).(*Metrics)
+	systemMetrics, ok := ctx.actorSystem.Extensions.Get(extensionID).(*Metrics)
 	if ok && ctx.actorSystem.Config.MetricsEnabled && systemMetrics.Enabled() {
 		_ctx := context.Background()
 		instruments := systemMetrics.metrics.Get(metrics.InternalActorMetrics)
@@ -548,7 +548,7 @@ func (ctx *actorContext) incarnateActor() {
 	ctx.actor = ctx.props.producer(ctx.actorSystem)
 
 	if ctx.actorSystem.Config.MetricsEnabled {
-		metricsSystem, ok := ctx.actorSystem.Extensions.Get(extensionId).(*Metrics)
+		metricsSystem, ok := ctx.actorSystem.Extensions.Get(extensionID).(*Metrics)
 		if ok && metricsSystem.Enabled() {
 			_ctx := context.Background()
 			if instruments := metricsSystem.metrics.Get(metrics.InternalActorMetrics); instruments != nil {
@@ -614,7 +614,7 @@ func (ctx *actorContext) handleRestart() {
 	ctx.tryRestartOrTerminate()
 
 	if ctx.actorSystem.Config.MetricsEnabled {
-		metricsSystem, ok := ctx.actorSystem.Extensions.Get(extensionId).(*Metrics)
+		metricsSystem, ok := ctx.actorSystem.Extensions.Get(extensionID).(*Metrics)
 		if ok && metricsSystem.Enabled() {
 			_ctx := context.Background()
 			if instruments := metricsSystem.metrics.Get(metrics.InternalActorMetrics); instruments != nil {
@@ -705,7 +705,7 @@ func (ctx *actorContext) finalizeStop() {
 	otherStopped := &Terminated{Who: ctx.self}
 	// Notify watchers
 	if ctx.extras != nil {
-		ctx.extras.watchers.ForEach(func(i int, pid *PID) {
+		ctx.extras.watchers.ForEach(func(_ int, pid *PID) {
 			pid.sendSystemMessage(ctx.actorSystem, otherStopped)
 		})
 	}
@@ -731,7 +731,7 @@ func (ctx *actorContext) EscalateFailure(reason interface{}, message interface{}
 	}
 
 	if ctx.actorSystem.Config.MetricsEnabled {
-		metricsSystem, ok := ctx.actorSystem.Extensions.Get(extensionId).(*Metrics)
+		metricsSystem, ok := ctx.actorSystem.Extensions.Get(extensionID).(*Metrics)
 		if ok && metricsSystem.Enabled() {
 			_ctx := context.Background()
 			if instruments := metricsSystem.metrics.Get(metrics.InternalActorMetrics); instruments != nil {

--- a/actor/actor_system.go
+++ b/actor/actor_system.go
@@ -10,6 +10,9 @@ import (
 	"github.com/lithammer/shortuuid/v4"
 )
 
+// ActorSystem is the runtime environment that hosts actors and manages their
+// execution, supervision, and system-wide services.
+//
 //goland:noinspection GoNameStartsWithPackageName
 type ActorSystem struct {
 	ProcessRegistry *ProcessRegistryValue
@@ -24,14 +27,17 @@ type ActorSystem struct {
 	logger          *slog.Logger
 }
 
+// Logger returns the logger associated with the actor system.
 func (as *ActorSystem) Logger() *slog.Logger {
 	return as.logger
 }
 
+// NewLocalPID creates a PID for a local actor with the given id.
 func (as *ActorSystem) NewLocalPID(id string) *PID {
 	return NewPID(as.ProcessRegistry.Address, id)
 }
 
+// Address returns the network address of the actor system.
 func (as *ActorSystem) Address() string {
 	return as.ProcessRegistry.Address
 }
@@ -66,12 +72,16 @@ func (as *ActorSystem) IsStopped() bool {
 	}
 }
 
+// NewActorSystem creates a new actor system with optional configuration
+// options.
 func NewActorSystem(options ...ConfigOption) *ActorSystem {
 	config := Configure(options...)
 
 	return NewActorSystemWithConfig(config)
 }
 
+// NewActorSystemWithConfig creates a new actor system using an explicit
+// configuration struct.
 func NewActorSystemWithConfig(config *Config) *ActorSystem {
 	system := &ActorSystem{}
 	system.ID = shortuuid.New()

--- a/actor/config.go
+++ b/actor/config.go
@@ -37,7 +37,7 @@ func defaultConfig() *Config {
 		DeadLetterThrottleCount:     3,
 		DeadLetterRequestLogging:    true,
 		DeveloperSupervisionLogging: false,
-		DiagnosticsSerializer: func(actor Actor) string {
+		DiagnosticsSerializer: func(_ Actor) string {
 			return ""
 		},
 		LoggerFactory: func(system *ActorSystem) *slog.Logger {

--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -76,7 +76,7 @@ func (dp *deadLetterProcess) SendUserMessage(pid *PID, message interface{}) {
 	_, msg, sender := UnwrapEnvelope(message)
 
 	if dp.actorSystem.Config.MetricsEnabled {
-		metricsSystem, ok := dp.actorSystem.Extensions.Get(extensionId).(*Metrics)
+		metricsSystem, ok := dp.actorSystem.Extensions.Get(extensionID).(*Metrics)
 		if ok && metricsSystem.Enabled() {
 			ctx := context.Background()
 			if instruments := metricsSystem.metrics.Get(metrics.InternalActorMetrics); instruments != nil {

--- a/actor/future.go
+++ b/actor/future.go
@@ -34,7 +34,7 @@ type Future interface {
 // newFuture creates and returns a new future with a timeout of duration d.
 func newFuture(actorSystem *ActorSystem, d time.Duration) *future {
 	ref := &futureProcess{future{actorSystem: actorSystem, cond: sync.NewCond(&sync.Mutex{})}}
-	id := actorSystem.ProcessRegistry.NextId()
+	id := actorSystem.ProcessRegistry.NextID()
 
 	pid, ok := actorSystem.ProcessRegistry.Add(ref, "future"+id)
 	if !ok {
@@ -42,7 +42,7 @@ func newFuture(actorSystem *ActorSystem, d time.Duration) *future {
 	}
 
 	if actorSystem.Config.MetricsEnabled {
-		sysMetrics, ok := actorSystem.Extensions.Get(extensionId).(*Metrics)
+		sysMetrics, ok := actorSystem.Extensions.Get(extensionID).(*Metrics)
 		if ok && sysMetrics.Enabled() {
 			if instruments := sysMetrics.metrics.Get(metrics.InternalActorMetrics); instruments != nil {
 				ctx := context.Background()
@@ -189,7 +189,7 @@ func (ref *futureProcess) SendSystemMessage(pid *PID, message interface{}) {
 
 func (ref *futureProcess) instrument() {
 	if ref.actorSystem.Config.MetricsEnabled {
-		sysMetrics, ok := ref.actorSystem.Extensions.Get(extensionId).(*Metrics)
+		sysMetrics, ok := ref.actorSystem.Extensions.Get(extensionID).(*Metrics)
 		if ok && sysMetrics.Enabled() {
 			ctx := context.Background()
 			labels := SystemLabels(ref.actorSystem)

--- a/actor/guardian.go
+++ b/actor/guardian.go
@@ -33,7 +33,7 @@ func (gs *guardiansValue) newGuardian(s SupervisorStrategy) *guardianProcess {
 		strategy:  s,
 		guardians: gs,
 	}
-	id := gs.actorSystem.ProcessRegistry.NextId()
+	id := gs.actorSystem.ProcessRegistry.NextID()
 
 	pid, ok := gs.actorSystem.ProcessRegistry.Add(ref, "guardian"+id)
 	if !ok {

--- a/actor/message.go
+++ b/actor/message.go
@@ -1,7 +1,9 @@
 package actor
 
-// The Producer type is a function that creates a new actor
+// Producer creates a new actor instance when invoked.
 type Producer func() Actor
+
+// ProducerWithActorSystem creates a new actor instance with access to the actor system.
 type ProducerWithActorSystem func(system *ActorSystem) Actor
 
 // Actor is the interface that defines the Receive method.
@@ -19,8 +21,11 @@ func (f ReceiveFunc) Receive(c Context) {
 	f(c)
 }
 
+// ReceiverFunc processes an incoming message envelope.
 type ReceiverFunc func(c ReceiverContext, envelope *MessageEnvelope)
 
+// SenderFunc processes an outgoing message envelope before delivery.
 type SenderFunc func(c SenderContext, target *PID, envelope *MessageEnvelope)
 
+// ContextDecoratorFunc modifies a context before it is used by an actor.
 type ContextDecoratorFunc func(ctx Context) Context

--- a/actor/message_batch.go
+++ b/actor/message_batch.go
@@ -1,5 +1,6 @@
 package actor
 
+// MessageBatch represents a collection of messages delivered together.
 type MessageBatch interface {
 	GetMessages() []interface{}
 }

--- a/actor/metrics.go
+++ b/actor/metrics.go
@@ -13,8 +13,9 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
-var extensionId = extensions.NextExtensionID()
+var extensionID = extensions.NextExtensionID()
 
+// Metrics provides access to system-wide metric instrumentation.
 type Metrics struct {
 	metrics     *metrics.ProtoMetrics
 	enabled     bool
@@ -23,12 +24,14 @@ type Metrics struct {
 
 var _ extensions.Extension = &Metrics{}
 
+// Enabled reports whether metrics collection is enabled.
 func (m *Metrics) Enabled() bool {
 	return m.enabled
 }
 
+// ExtensionID returns the unique ID for the metrics extension.
 func (m *Metrics) ExtensionID() extensions.ExtensionID {
-	return extensionId
+	return extensionID
 }
 
 // NewMetrics initializes metrics collection for the given actor system using the

--- a/actor/pid.go
+++ b/actor/pid.go
@@ -54,6 +54,8 @@ func (pid *PID) sendSystemMessage(actorSystem *ActorSystem, message interface{})
 	pid.ref(actorSystem).SendSystemMessage(pid, message)
 }
 
+// Equal reports whether two PIDs refer to the same actor instance.
+//
 //goland:noinspection GoReceiverNames.
 func (pid *PID) Equal(other *PID) bool {
 	if pid != nil && other == nil {

--- a/actor/pidset.go
+++ b/actor/pidset.go
@@ -1,5 +1,6 @@
 package actor
 
+// PIDSet is a set of PIDs backed by a slice and lookup map.
 type PIDSet struct {
 	pids   []*PID
 	lookup map[pidKey]int
@@ -38,6 +39,7 @@ func (p *PIDSet) indexOf(v *PID) int {
 	return -1
 }
 
+// Contains reports whether v is present in the set.
 func (p *PIDSet) Contains(v *PID) bool {
 	_, ok := p.lookup[p.key(v)]
 	return ok
@@ -103,10 +105,12 @@ func (p *PIDSet) ForEach(f func(i int, pid *PID)) {
 	}
 }
 
+// Get returns the PID at the specified index.
 func (p *PIDSet) Get(index int) *PID {
 	return p.pids[index]
 }
 
+// Clone creates a shallow copy of the PID set.
 func (p *PIDSet) Clone() *PIDSet {
 	return NewPIDSet(p.pids...)
 }

--- a/actor/process_registry.go
+++ b/actor/process_registry.go
@@ -66,7 +66,7 @@ const (
 	digits = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ~+"
 )
 
-func uint64ToId(u uint64) string {
+func uint64ToID(u uint64) string {
 	var buf [13]byte
 	i := 13
 	// base is power of 2: use shifts and masks instead of / and %
@@ -84,11 +84,11 @@ func uint64ToId(u uint64) string {
 	return string(buf[i:])
 }
 
-// NextId returns the next unique process identifier.
-func (pr *ProcessRegistryValue) NextId() string {
+// NextID returns the next unique process identifier.
+func (pr *ProcessRegistryValue) NextID() string {
 	counter := atomic.AddUint64(&pr.SequenceID, 1)
 
-	return uint64ToId(counter)
+	return uint64ToID(counter)
 }
 
 // Add registers a process with the given id and returns its PID.

--- a/actor/process_registry_test.go
+++ b/actor/process_registry_test.go
@@ -20,7 +20,7 @@ func TestUint64ToId(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.e, func(t *testing.T) {
-			s := uint64ToId(tc.i)
+			s := uint64ToID(tc.i)
 			assert.Equal(t, tc.e, s)
 		})
 	}
@@ -31,7 +31,7 @@ var ss string
 func BenchmarkUint64ToId(b *testing.B) {
 	var s string
 	for i := 0; i < b.N; i++ {
-		s = uint64ToId(uint64(i) << 5)
+		s = uint64ToID(uint64(i) << 5)
 	}
 	ss = s
 }

--- a/actor/root_context.go
+++ b/actor/root_context.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// RootContext is the entry point used to interact with the actor system.
 type RootContext struct {
 	actorSystem      *ActorSystem
 	senderMiddleware SenderFunc
@@ -45,12 +46,14 @@ func (rc *RootContext) Logger() *slog.Logger {
 	return rc.actorSystem.Logger()
 }
 
+// WithHeaders sets the message headers used for subsequent sends and requests.
 func (rc *RootContext) WithHeaders(headers map[string]string) *RootContext {
 	rc.headers = headers
 
 	return rc
 }
 
+// WithSenderMiddleware applies sender middleware to outgoing messages.
 func (rc *RootContext) WithSenderMiddleware(middleware ...SenderMiddleware) *RootContext {
 	rc.senderMiddleware = makeSenderMiddlewareChain(middleware, func(_ SenderContext, target *PID, envelope *MessageEnvelope) {
 		target.sendUserMessage(rc.actorSystem, envelope)
@@ -59,14 +62,16 @@ func (rc *RootContext) WithSenderMiddleware(middleware ...SenderMiddleware) *Roo
 	return rc
 }
 
+// WithSpawnMiddleware applies spawn middleware when creating child actors.
 func (rc *RootContext) WithSpawnMiddleware(middleware ...SpawnMiddleware) *RootContext {
-	rc.spawnMiddleware = makeSpawnMiddlewareChain(middleware, func(actorSystem *ActorSystem, id string, props *Props, parentContext SpawnerContext) (pid *PID, e error) {
+	rc.spawnMiddleware = makeSpawnMiddlewareChain(middleware, func(actorSystem *ActorSystem, id string, props *Props, _ SpawnerContext) (pid *PID, e error) {
 		return props.spawn(actorSystem, id, rc)
 	})
 
 	return rc
 }
 
+// WithGuardian sets a guardian strategy used when spawning actors.
 func (rc *RootContext) WithGuardian(guardian SupervisorStrategy) *RootContext {
 	rc.guardianStrategy = guardian
 
@@ -77,10 +82,12 @@ func (rc *RootContext) WithGuardian(guardian SupervisorStrategy) *RootContext {
 // Interface: info
 //
 
+// Parent returns the PID of the parent actor. RootContext has no parent and returns nil.
 func (rc *RootContext) Parent() *PID {
 	return nil
 }
 
+// Self returns the PID representing the root context.
 func (rc *RootContext) Self() *PID {
 	if rc.guardianStrategy != nil {
 		return rc.actorSystem.Guardians.getGuardianPid(rc.guardianStrategy)
@@ -89,10 +96,12 @@ func (rc *RootContext) Self() *PID {
 	return nil
 }
 
+// Sender returns the PID of the message sender if available.
 func (rc *RootContext) Sender() *PID {
 	return nil
 }
 
+// Actor always returns nil for RootContext since it does not represent a real actor.
 func (rc *RootContext) Actor() Actor {
 	return nil
 }
@@ -101,22 +110,27 @@ func (rc *RootContext) Actor() Actor {
 // Interface: sender
 //
 
+// Message always returns nil for RootContext since it is not processing a message.
 func (rc *RootContext) Message() interface{} {
 	return nil
 }
 
+// MessageHeader returns the headers attached to the current context.
 func (rc *RootContext) MessageHeader() ReadonlyMessageHeader {
 	return rc.headers
 }
 
+// Send delivers a message to the given PID using the configured middleware chain.
 func (rc *RootContext) Send(pid *PID, message interface{}) {
 	rc.sendUserMessage(pid, message)
 }
 
+// Request sends a message to the given PID expecting a response.
 func (rc *RootContext) Request(pid *PID, message interface{}) {
 	rc.sendUserMessage(pid, message)
 }
 
+// RequestWithCustomSender sends a message on behalf of the provided sender PID.
 func (rc *RootContext) RequestWithCustomSender(pid *PID, message interface{}, sender *PID) {
 	env := &MessageEnvelope{
 		Header:  nil,
@@ -155,7 +169,7 @@ func (rc *RootContext) sendUserMessage(pid *PID, message interface{}) {
 
 // Spawn starts a new actor based on props and named with a unique id.
 func (rc *RootContext) Spawn(props *Props) *PID {
-	pid, err := rc.SpawnNamed(props, rc.actorSystem.ProcessRegistry.NextId())
+	pid, err := rc.SpawnNamed(props, rc.actorSystem.ProcessRegistry.NextID())
 	if err != nil {
 		panic(err)
 	}
@@ -165,7 +179,7 @@ func (rc *RootContext) Spawn(props *Props) *PID {
 
 // SpawnPrefix starts a new actor based on props and named using a prefix followed by a unique id.
 func (rc *RootContext) SpawnPrefix(props *Props, prefix string) *PID {
-	pid, err := rc.SpawnNamed(props, prefix+rc.actorSystem.ProcessRegistry.NextId())
+	pid, err := rc.SpawnNamed(props, prefix+rc.actorSystem.ProcessRegistry.NextID())
 	if err != nil {
 		panic(err)
 	}

--- a/cluster/clusterproviders/test/test_provider.go
+++ b/cluster/clusterproviders/test/test_provider.go
@@ -11,10 +11,10 @@ import (
 
 // ProviderConfig holds configuration values for the in-memory test provider.
 type ProviderConfig struct {
-	// ServiceTtl is the time to live for services. Default: 3s
-	ServiceTtl time.Duration
-	// RefreshTtl is the time between refreshes of the service ttl. Default: 1s
-	RefreshTtl time.Duration
+	// ServiceTTL is the time to live for services. Default: 3s
+	ServiceTTL time.Duration
+	// RefreshTTL is the time between refreshes of the service ttl. Default: 1s
+	RefreshTTL time.Duration
 	// DeregisterCritical is the time after which a service is deregistered if it is not refreshed. Default: 10s
 	DeregisterCritical time.Duration
 }
@@ -22,17 +22,17 @@ type ProviderConfig struct {
 // ProviderOption configures a test provider instance.
 type ProviderOption func(config *ProviderConfig)
 
-// WithTestProviderServiceTtl sets the service ttl. Default: 3s
-func WithTestProviderServiceTtl(serviceTtl time.Duration) ProviderOption {
+// WithTestProviderServiceTTL sets the service ttl. Default: 3s
+func WithTestProviderServiceTTL(serviceTTL time.Duration) ProviderOption {
 	return func(config *ProviderConfig) {
-		config.ServiceTtl = serviceTtl
+		config.ServiceTTL = serviceTTL
 	}
 }
 
-// WithTestProviderRefreshTtl sets the refresh ttl. Default: 1s
-func WithTestProviderRefreshTtl(refreshTtl time.Duration) ProviderOption {
+// WithTestProviderRefreshTTL sets the refresh ttl. Default: 1s
+func WithTestProviderRefreshTTL(refreshTTL time.Duration) ProviderOption {
 	return func(config *ProviderConfig) {
-		config.RefreshTtl = refreshTtl
+		config.RefreshTTL = refreshTTL
 	}
 }
 
@@ -57,8 +57,8 @@ type Provider struct {
 // NewTestProvider creates a new Provider backed by the given in-memory agent.
 func NewTestProvider(agent *InMemAgent, options ...ProviderOption) *Provider {
 	config := &ProviderConfig{
-		ServiceTtl:         time.Second * 3,
-		RefreshTtl:         time.Second,
+		ServiceTTL:         time.Second * 3,
+		RefreshTTL:         time.Second,
 		DeregisterCritical: time.Second * 10,
 	}
 	for _, option := range options {
@@ -82,7 +82,7 @@ func (t *Provider) StartMember(c *cluster.Cluster) error {
 	kinds := c.GetClusterKinds()
 	t.cluster = c
 	t.id = c.ActorSystem.ID
-	t.startTtlReport()
+	t.startTTLReport()
 	t.agent.SubscribeStatusUpdate(t.notifyStatuses)
 	t.agent.RegisterService(NewAgentServiceStatus(t.id, host, port, kinds))
 	return nil
@@ -127,9 +127,9 @@ func (t *Provider) notifyStatuses() {
 	t.memberList.UpdateClusterTopology(members)
 }
 
-// startTtlReport starts the ttl report loop.
-func (t *Provider) startTtlReport() {
-	t.ttlReportTicker = time.NewTicker(t.config.RefreshTtl)
+// startTTLReport starts the ttl report loop.
+func (t *Provider) startTTLReport() {
+	t.ttlReportTicker = time.NewTicker(t.config.RefreshTTL)
 	go func() {
 		for range t.ttlReportTicker.C {
 			t.agent.RefreshServiceTTL(t.id)

--- a/cluster/identity_storage_lookup.go
+++ b/cluster/identity_storage_lookup.go
@@ -11,7 +11,7 @@ const (
 	pidClusterIdentityStartIndex = len(placementActorName) + 1
 )
 
-// IdentityStorageLookup contains
+// IdentityStorageLookup connects identity storage with the cluster for locating actors.
 type IdentityStorageLookup struct {
 	Storage        StorageLookup
 	cluster        *Cluster
@@ -23,15 +23,15 @@ type IdentityStorageLookup struct {
 }
 
 func newIdentityStorageLookup(storage StorageLookup) *IdentityStorageLookup {
-	this := &IdentityStorageLookup{
+	isl := &IdentityStorageLookup{
 		Storage: storage,
 	}
-	return this
+	return isl
 }
 
 // RemoveMember from identity storage
-func (i *IdentityStorageLookup) RemoveMember(memberID string) {
-	i.Storage.RemoveMemberId(memberID)
+func (isl *IdentityStorageLookup) RemoveMember(memberID string) {
+	isl.Storage.RemoveMemberId(memberID)
 }
 
 // RemotePlacementActor returns the PID of the remote placement actor
@@ -44,20 +44,20 @@ func RemotePlacementActor(address string) *actor.PID {
 //
 
 // Get returns a PID for a given ClusterIdentity
-func (id *IdentityStorageLookup) Get(clusterIdentity *ClusterIdentity) *actor.PID {
+func (isl *IdentityStorageLookup) Get(clusterIdentity *ClusterIdentity) *actor.PID {
 	msg := newGetPid(clusterIdentity)
 	timeout := 5 * time.Second
 
-	res, _ := id.system.Root.RequestFuture(id.router, msg, timeout).Result()
+	res, _ := isl.system.Root.RequestFuture(isl.router, msg, timeout).Result()
 	response := res.(actor.Future)
 
 	return response.PID()
 }
 
-func (id *IdentityStorageLookup) Setup(cluster *Cluster, kinds []string, isClient bool) {
-	id.cluster = cluster
-	id.system = cluster.ActorSystem
-	id.memberID = cluster.ActorSystem.ID
+func (isl *IdentityStorageLookup) Setup(cluster *Cluster, _ []string, _ bool) {
+	isl.cluster = cluster
+	isl.system = cluster.ActorSystem
+	isl.memberID = cluster.ActorSystem.ID
 
 	// workerProps := actor.PropsFromProducer(func() actor.Actor { return newIdentityStorageWorker(identity) })
 

--- a/cluster/identitylookup/disthash/identity_lookup.go
+++ b/cluster/identitylookup/disthash/identity_lookup.go
@@ -26,7 +26,7 @@ func (p *IdentityLookup) RemovePid(clusterIdentity *cluster.ClusterIdentity, pid
 }
 
 // Setup initializes the identity lookup for the given cluster.
-func (p *IdentityLookup) Setup(cluster *cluster.Cluster, kinds []string, isClient bool) {
+func (p *IdentityLookup) Setup(cluster *cluster.Cluster, _ []string, _ bool) {
 	p.partitionManager = newPartitionManager(cluster)
 	p.partitionManager.Start()
 }

--- a/cluster/key_value_store.go
+++ b/cluster/key_value_store.go
@@ -15,11 +15,14 @@ type KeyValueStore[T any] interface {
 // EmptyKeyValueStore is a key value store that does nothing.
 type EmptyKeyValueStore[T any] struct{}
 
+// Set discards the key and value and always returns nil.
 func (e *EmptyKeyValueStore[T]) Set(_ context.Context, _ string, _ T) error { return nil }
 
+// Get always returns the zero value for T and no error.
 func (e *EmptyKeyValueStore[T]) Get(_ context.Context, _ string) (T, error) {
 	var r T
 	return r, nil
 }
 
+// Clear is a no-op that always returns nil.
 func (e *EmptyKeyValueStore[T]) Clear(_ context.Context, _ string) error { return nil }

--- a/cluster/member_status.go
+++ b/cluster/member_status.go
@@ -1,11 +1,13 @@
 package cluster
 
+// MemberStatus represents the availability of a member in the cluster.
 type MemberStatus struct {
 	Member
 	MemberID string // for compatibility
 	Alive    bool
 }
 
+// Address returns the network address of the member.
 func (m *MemberStatus) Address() string {
 	return m.Member.Address()
 }

--- a/cluster/pubsub_topic.go
+++ b/cluster/pubsub_topic.go
@@ -12,6 +12,7 @@ import (
 
 const TopicActorKind = "prototopic"
 
+// TopicActor manages subscriptions and publishes messages for a topic.
 type TopicActor struct {
 	topic                string
 	subscribers          map[subscribeIdentityStruct]*SubscriberIdentity
@@ -20,6 +21,7 @@ type TopicActor struct {
 	shouldThrottle       actor.ShouldThrottle
 }
 
+// NewTopicActor creates a new TopicActor using the provided store and logger.
 func NewTopicActor(store KeyValueStore[*Subscribers], logger *slog.Logger) *TopicActor {
 	return &TopicActor{
 		subscriptionStore: store,
@@ -30,6 +32,7 @@ func NewTopicActor(store KeyValueStore[*Subscribers], logger *slog.Logger) *Topi
 	}
 }
 
+// Receive processes actor lifecycle and pub-sub messages.
 func (t *TopicActor) Receive(c actor.Context) {
 	switch msg := c.Message().(type) {
 	case *actor.Started:

--- a/cluster/rendezvous.go
+++ b/cluster/rendezvous.go
@@ -15,6 +15,8 @@ type memberData struct {
 	member    *Member
 	hashBytes []byte
 }
+
+// Rendezvous implements rendezvous hashing for distributing identities across cluster members.
 type Rendezvous struct {
 	mutex      sync.RWMutex
 	hasher     hash.Hash32
@@ -22,6 +24,7 @@ type Rendezvous struct {
 	members    []*memberData
 }
 
+// NewRendezvous creates a new rendezvous hashing instance.
 func NewRendezvous() *Rendezvous {
 	return &Rendezvous{
 		hasher:  fnv.New32a(),
@@ -29,6 +32,7 @@ func NewRendezvous() *Rendezvous {
 	}
 }
 
+// GetByClusterIdentity returns the member address responsible for the given identity.
 func (r *Rendezvous) GetByClusterIdentity(ci *ClusterIdentity) string {
 	r.mutex.RLock()
 	defer r.mutex.RUnlock()
@@ -66,6 +70,7 @@ func (r *Rendezvous) GetByClusterIdentity(ci *ClusterIdentity) string {
 	return maxMember.member.Address()
 }
 
+// GetByIdentity parses a combined kind/identity string and returns the member address.
 func (r *Rendezvous) GetByIdentity(identity string) string {
 	parts := strings.SplitN(identity, "/", 2)
 
@@ -85,6 +90,7 @@ func (r *Rendezvous) memberDataByKind(kind string) []*memberData {
 	return m
 }
 
+// UpdateMembers replaces the internal member list used for hashing.
 func (r *Rendezvous) UpdateMembers(members Members) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()

--- a/remote/activator_actor.go
+++ b/remote/activator_actor.go
@@ -111,7 +111,7 @@ func (a *activator) Receive(context actor.Context) {
 
 		// unnamed actor, assign auto ExtensionID
 		if name == "" {
-			name = context.ActorSystem().ProcessRegistry.NextId()
+			name = context.ActorSystem().ProcessRegistry.NextID()
 		}
 
 		pid, err := context.SpawnNamed(props, "Remote$"+name)

--- a/remote/endpoint_manager.go
+++ b/remote/endpoint_manager.go
@@ -19,8 +19,8 @@ type endpointLazy struct {
 	address  string
 }
 
-// NewEndpointLazy creates an endpoint that connects to the remote address on first use.
-func NewEndpointLazy(em *endpointManager, address string) *endpointLazy {
+// newEndpointLazy creates an endpoint that connects to the remote address on first use.
+func newEndpointLazy(em *endpointManager, address string) *endpointLazy {
 	return &endpointLazy{
 		manager: em,
 		address: address,
@@ -216,7 +216,7 @@ func (em *endpointManager) remoteDeliver(msg *remoteDeliver) {
 func (em *endpointManager) ensureConnected(address string) *endpoint {
 	e, ok := em.connections.Load(address)
 	if !ok {
-		el := NewEndpointLazy(em, address)
+		el := newEndpointLazy(em, address)
 		e, _ = em.connections.LoadOrStore(address, el)
 	}
 	el := e.(*endpointLazy)
@@ -281,7 +281,7 @@ func (state *endpointSupervisor) Receive(ctx actor.Context) {
 	}
 }
 
-func (state *endpointSupervisor) HandleFailure(actorSystem *actor.ActorSystem, supervisor actor.Supervisor, child *actor.PID, rs *actor.RestartStatistics, reason interface{}, message interface{}) {
+func (state *endpointSupervisor) HandleFailure(actorSystem *actor.ActorSystem, supervisor actor.Supervisor, child *actor.PID, _ *actor.RestartStatistics, reason interface{}, message interface{}) {
 	actorSystem.Logger().Debug("EndpointSupervisor handling failure", slog.Any("reason", reason), slog.Any("message", message))
 	// use restart will cause a start loop, just stop it for now
 	// supervisor.RestartChildren(child)

--- a/remote/endpoint_reader.go
+++ b/remote/endpoint_reader.go
@@ -23,11 +23,11 @@ func (s *endpointReader) mustEmbedUnimplementedRemotingServer() {
 	panic("implement me")
 }
 
-func (s *endpointReader) ListProcesses(ctx context.Context, request *ListProcessesRequest) (*ListProcessesResponse, error) {
+func (s *endpointReader) ListProcesses(_ context.Context, _ *ListProcessesRequest) (*ListProcessesResponse, error) {
 	panic("implement me")
 }
 
-func (s *endpointReader) GetProcessDiagnostics(ctx context.Context, request *GetProcessDiagnosticsRequest) (*GetProcessDiagnosticsResponse, error) {
+func (s *endpointReader) GetProcessDiagnostics(_ context.Context, _ *GetProcessDiagnosticsRequest) (*GetProcessDiagnosticsResponse, error) {
 	panic("implement me")
 }
 
@@ -194,24 +194,24 @@ func (s *endpointReader) onMessageBatch(m *MessageBatch) error {
 	return nil
 }
 
-func deserializeSender(pid *actor.PID, index int32, requestId uint32, arr []*actor.PID) *actor.PID {
+func deserializeSender(pid *actor.PID, index int32, requestID uint32, arr []*actor.PID) *actor.PID {
 	if index == 0 {
 		pid = nil
 	} else {
 		pid = arr[index-1]
 
 		// if request id is used. make sure to clone the PID first, so we don't corrupt the lookup
-		if requestId > 0 {
+		if requestID > 0 {
 			pid, _ = proto.Clone(pid).(*actor.PID)
-			pid.RequestId = requestId
+			pid.RequestId = requestID
 		}
 	}
 	return pid
 }
 
-func deserializeTarget(index int32, requestId uint32, arr []string, address string) *actor.PID {
+func deserializeTarget(index int32, requestID uint32, arr []string, address string) *actor.PID {
 	pid := actor.NewPID(address, arr[index])
-	pid.RequestId = requestId
+	pid.RequestId = requestID
 	return pid
 }
 

--- a/remote/endpoint_watcher.go
+++ b/remote/endpoint_watcher.go
@@ -65,7 +65,7 @@ func (state *endpointWatcher) connected(ctx actor.Context) {
 			// try to find the watcher ExtensionID in the local actor registry
 			ref, ok := state.remote.actorSystem.ProcessRegistry.GetLocal(id)
 			if ok {
-				pidSet.ForEach(func(i int, pid *actor.PID) {
+				pidSet.ForEach(func(_ int, pid *actor.PID) {
 					// create a terminated event for the Watched actor
 					terminated := &actor.Terminated{
 						Who: pid,

--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -36,7 +36,7 @@ type restartAfterConnectFailure struct {
 	err error
 }
 
-func (state *endpointWriter) initialize(ctx actor.Context) {
+func (state *endpointWriter) initialize(_ actor.Context) {
 	now := time.Now()
 
 	state.remote.Logger().Info("Started EndpointWriter. connecting", slog.String("address", state.address))
@@ -288,23 +288,23 @@ func (state *endpointWriter) sendEnvelopes(msg []interface{}, ctx actor.Context)
 }
 
 func addToLookup(m map[string]int32, name string, a []string) (int32, []string) {
-	max := int32(len(m))
+	maxIdx := int32(len(m))
 	id, ok := m[name]
 	if !ok {
-		m[name] = max
-		id = max
+		m[name] = maxIdx
+		id = maxIdx
 		a = append(a, name)
 	}
 	return id, a
 }
 
 func addToTargetLookup(m map[string]int32, pid *actor.PID, arr []string) (int32, []string) {
-	max := int32(len(m))
+	maxIdx := int32(len(m))
 	key := pid.Address + "/" + pid.Id
 	id, ok := m[key]
 	if !ok {
-		m[key] = max
-		id = max
+		m[key] = maxIdx
+		id = maxIdx
 		arr = append(arr, pid.Id)
 	}
 	return id, arr
@@ -315,14 +315,14 @@ func addToSenderLookup(m map[string]int32, pid *actor.PID, arr []*actor.PID) (in
 		return 0, arr
 	}
 
-	max := int32(len(m))
+	maxIdx := int32(len(m))
 	key := pid.Address + "/" + pid.Id
 	id, ok := m[key]
 	if !ok {
 		c, _ := proto.Clone(pid).(*actor.PID)
 		c.RequestId = 0
-		m[key] = max
-		id = max
+		m[key] = maxIdx
+		id = maxIdx
 		arr = append(arr, c)
 	}
 	return id + 1, arr

--- a/remote/json_serializer.go
+++ b/remote/json_serializer.go
@@ -14,7 +14,7 @@ type jsonSerializer struct {
 	jsonpb.Unmarshaler
 }
 
-func newJsonSerializer() Serializer {
+func newJSONSerializer() Serializer {
 	return &jsonSerializer{
 		Marshaler: jsonpb.Marshaler{},
 		Unmarshaler: jsonpb.Unmarshaler{
@@ -24,8 +24,8 @@ func newJsonSerializer() Serializer {
 }
 
 func (j *jsonSerializer) Serialize(msg interface{}) ([]byte, error) {
-	if message, ok := msg.(*JsonMessage); ok {
-		return []byte(message.Json), nil
+	if message, ok := msg.(*JSONMessage); ok {
+		return []byte(message.JSON), nil
 	} else if message, ok := msg.(proto.Message); ok {
 
 		str, err := j.Marshaler.MarshalToString(message)
@@ -41,9 +41,9 @@ func (j *jsonSerializer) Serialize(msg interface{}) ([]byte, error) {
 func (j *jsonSerializer) Deserialize(typeName string, b []byte) (interface{}, error) {
 	protoType := proto.MessageType(typeName)
 	if protoType == nil {
-		m := &JsonMessage{
+		m := &JSONMessage{
 			TypeName: typeName,
-			Json:     string(b),
+			JSON:     string(b),
 		}
 		return m, nil
 	}
@@ -62,7 +62,7 @@ func (j *jsonSerializer) Deserialize(typeName string, b []byte) (interface{}, er
 }
 
 func (j *jsonSerializer) GetTypeName(msg interface{}) (string, error) {
-	if message, ok := msg.(*JsonMessage); ok {
+	if message, ok := msg.(*JSONMessage); ok {
 		return message.TypeName, nil
 	} else if message, ok := msg.(proto.Message); ok {
 		typeName := proto.MessageName(message)

--- a/remote/messages.go
+++ b/remote/messages.go
@@ -35,10 +35,10 @@ type remoteTerminate struct {
 	Watchee *actor.PID
 }
 
-// JsonMessage carries a JSON encoded message and its type name.
-type JsonMessage struct {
+// JSONMessage carries a JSON encoded payload and its type name.
+type JSONMessage struct {
 	TypeName string
-	Json     string
+	JSON     string
 }
 
 var stopMessage interface{} = &actor.Stop{}

--- a/remote/metrics/remote_metrics.go
+++ b/remote/metrics/remote_metrics.go
@@ -10,6 +10,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+// RemoteMetrics contains OpenTelemetry instruments used to track remote
+// actor operations such as message serialization and endpoint state.
 type RemoteMetrics struct {
 	RemoteWriteDuration             metric.Float64Histogram
 	RemoteActorSpawnCount           metric.Int64Counter
@@ -19,6 +21,8 @@ type RemoteMetrics struct {
 	RemoteEndpointDisconnectedCount metric.Int64Counter
 }
 
+// NewRemoteMetrics creates all metric instruments required for reporting remote
+// activity to OpenTelemetry. Any failures to create instruments are logged.
 func NewRemoteMetrics(logger *slog.Logger) *RemoteMetrics {
 	meter := otel.Meter(metrics.LibName)
 	m := &RemoteMetrics{}

--- a/remote/response_status_code_test.go
+++ b/remote/response_status_code_test.go
@@ -19,8 +19,7 @@ func TestStatusCode_String(t *testing.T) {
 func TestStatusCode_Error(t *testing.T) {
 	assert := assert.New(t)
 	for i := 0; i < int(ResponseStatusCodeMAX); i++ {
-		var err error = nil
-		err = &ResponseError{ResponseStatusCode(i)}
+		err := &ResponseError{ResponseStatusCode(i)}
 		assert.Error(err)
 	}
 }

--- a/remote/serializer.go
+++ b/remote/serializer.go
@@ -8,7 +8,7 @@ var (
 
 func init() {
 	RegisterSerializer(newProtoSerializer())
-	RegisterSerializer(newJsonSerializer())
+	RegisterSerializer(newJSONSerializer())
 }
 
 // RegisterSerializer registers a Serializer implementation.

--- a/remote/server.go
+++ b/remote/server.go
@@ -15,7 +15,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 )
 
-var extensionId = extensions.NextExtensionID()
+var extensionID = extensions.NextExtensionID()
 
 // Remote enables communication between actors across network boundaries.
 type Remote struct {
@@ -57,14 +57,14 @@ func NewRemote(actorSystem *actor.ActorSystem, config *Config) *Remote {
 //
 //goland:noinspection GoUnusedExportedFunction
 func GetRemote(actorSystem *actor.ActorSystem) *Remote {
-	r := actorSystem.Extensions.Get(extensionId)
+	r := actorSystem.Extensions.Get(extensionID)
 
 	return r.(*Remote)
 }
 
 // ExtensionID returns the unique ID of the Remote extension.
 func (r *Remote) ExtensionID() extensions.ExtensionID {
-	return extensionId
+	return extensionID
 }
 
 // BlockList returns the list of blocked members.

--- a/remote/server_test.go
+++ b/remote/server_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestStart(t *testing.T) {
+func TestStart(_ *testing.T) {
 	system := actor.NewActorSystem()
 	config := Configure("localhost", 0)
 	remote := NewRemote(system, config)

--- a/remote/tests/remote_metrics_test.go
+++ b/remote/tests/remote_metrics_test.go
@@ -40,6 +40,7 @@ func TestRemoteMetrics(t *testing.T) {
 	remote2.Register("echo", actor.PropsFromFunc(func(ctx actor.Context) {
 		if _, ok := ctx.Message().(*remote.ActorPidRequest); ok {
 			// no-op
+			return
 		}
 	}))
 	remote2.Start()


### PR DESCRIPTION
## Summary
- document and tidy Remote metrics and context helpers
- rename inconsistent identifiers and drop unused parameters
- add comments and clean up key cluster utilities

## Testing
- `go test ./actor/... ./remote/... ./cluster/... 2>&1 | head -n 200`


------
https://chatgpt.com/codex/tasks/task_e_689cb230d9f4832893abecd0dd385374