### PR TITLE
Add remote and cluster reconnection tests

### DIFF
--- a/cluster/membership_recovery_test.go
+++ b/cluster/membership_recovery_test.go
@@ -13,11 +13,16 @@ import (
 // testProvider implements an in-memory ClusterProvider used only by tests.
 // Tests use it to manually manage the member list so topology changes and
 // recoveries can be simulated without real networking. Members are keyed by
-// their ActorSystem IDs so a restarted node is treated as a brand new member.
+// their ActorSystem IDs rather than address, mirroring real cluster semantics
+// where a rebooted node receives a new system ID and must be treated as a
+// completely new member.
 type testProvider struct {
-	mu       sync.Mutex
-	members  map[string]*Member
-	clusters []*Cluster
+        mu sync.Mutex
+        // members are keyed by ActorSystem ID to emulate node identity in the
+        // production provider. A restarted node gets a new ID, so using the ID
+        // as the map key prevents accidental reuse of stale memberships.
+        members  map[string]*Member
+        clusters []*Cluster
 }
 
 // newTestProvider constructs a fresh testProvider for unit tests.

--- a/cluster/membership_recovery_test.go
+++ b/cluster/membership_recovery_test.go
@@ -1,7 +1,6 @@
 package cluster
 
 import (
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -13,7 +12,8 @@ import (
 
 // testProvider implements an in-memory ClusterProvider used only by tests.
 // Tests use it to manually manage the member list so topology changes and
-// recoveries can be simulated without real networking.
+// recoveries can be simulated without real networking. Members are keyed by
+// their ActorSystem IDs so a restarted node is treated as a brand new member.
 type testProvider struct {
 	mu       sync.Mutex
 	members  map[string]*Member
@@ -41,10 +41,11 @@ func (p *testProvider) publish() {
 
 // StartMember registers the given cluster with the provider and immediately
 // publishes the updated topology. Tests call this to simulate a node joining
-// the cluster.
+// the cluster. A member's ID is its ActorSystem's unique ID, matching the real
+// cluster providers' behaviour.
 func (p *testProvider) StartMember(c *Cluster) error {
 	host, port, _ := c.ActorSystem.GetHostPort()
-	self := &Member{Host: host, Port: int32(port), Id: fmt.Sprintf("%s@%s:%d", c.Config.Name, host, port), Kinds: c.GetClusterKinds()}
+	self := &Member{Host: host, Port: int32(port), Id: c.ActorSystem.ID, Kinds: c.GetClusterKinds()}
 	p.mu.Lock()
 	p.members[self.Id] = self
 	p.clusters = append(p.clusters, c)
@@ -63,16 +64,16 @@ func (p *testProvider) Shutdown(bool) error { return nil }
 // removeCluster deletes the cluster from the member list and broadcasts the
 // change. Tests use it to simulate a node failure.
 func (p *testProvider) removeCluster(c *Cluster) {
-	host, port, _ := c.ActorSystem.GetHostPort()
-	id := fmt.Sprintf("%s@%s:%d", c.Config.Name, host, port)
+	id := c.ActorSystem.ID
 	p.mu.Lock()
 	delete(p.members, id)
 	p.mu.Unlock()
 	p.publish()
 }
 
-// membershipRecovery restarts a previously stopped cluster node and
-// re-registers it with the test provider to mimic a recovered member.
+// membershipRecovery starts the supplied cluster node. Tests invoke this on a
+// freshly created cluster instance to mimic a rebooted member rejoining with a
+// new ActorSystem ID.
 func membershipRecovery(c *Cluster) {
 	c.StartMember()
 }
@@ -108,12 +109,12 @@ func TestCluster_MembershipRecovery(t *testing.T) {
 	prov.removeCluster(c2)
 	c2.Shutdown(true)
 
-	fut = c1.ActorSystem.Root.RequestFuture(pid2, &emptypb.Empty{}, 200*time.Millisecond)
-	_, err = fut.Result()
-	assert.Error(t, err)
+	// the provider broadcasts the removal which clears the PID cache
+	_, ok = c1.PidCache.Get("echo", "echo")
+	assert.False(t, ok)
 	assert.Equal(t, 1, c1.MemberList.Length())
 
-	// node recovers with a fresh cluster instance
+	// node recovers with a fresh cluster instance and new system ID
 	c2a := newClusterForTest("node2", prov, WithKinds(kind))
 	membershipRecovery(c2a)
 	pid2a, err := c2a.ActorSystem.Root.SpawnNamed(kind.Props, "echo")

--- a/cluster/membership_recovery_test.go
+++ b/cluster/membership_recovery_test.go
@@ -1,0 +1,129 @@
+package cluster
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// testProvider implements an in-memory ClusterProvider used only by tests.
+// Tests use it to manually manage the member list so topology changes and
+// recoveries can be simulated without real networking.
+type testProvider struct {
+	mu       sync.Mutex
+	members  map[string]*Member
+	clusters []*Cluster
+}
+
+// newTestProvider constructs a fresh testProvider for unit tests.
+func newTestProvider() *testProvider {
+	return &testProvider{members: make(map[string]*Member)}
+}
+
+// publish broadcasts the current member set to all registered clusters.
+// It emulates the membership dissemination a real provider would perform.
+func (p *testProvider) publish() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	var ms Members
+	for _, m := range p.members {
+		ms = append(ms, m)
+	}
+	for _, c := range p.clusters {
+		c.MemberList.UpdateClusterTopology(ms)
+	}
+}
+
+// StartMember registers the given cluster with the provider and immediately
+// publishes the updated topology. Tests call this to simulate a node joining
+// the cluster.
+func (p *testProvider) StartMember(c *Cluster) error {
+	host, port, _ := c.ActorSystem.GetHostPort()
+	self := &Member{Host: host, Port: int32(port), Id: fmt.Sprintf("%s@%s:%d", c.Config.Name, host, port), Kinds: c.GetClusterKinds()}
+	p.mu.Lock()
+	p.members[self.Id] = self
+	p.clusters = append(p.clusters, c)
+	p.mu.Unlock()
+	p.publish()
+	return nil
+}
+
+// StartClient mirrors StartMember because the test provider makes no
+// distinction between clients and members.
+func (p *testProvider) StartClient(c *Cluster) error { return p.StartMember(c) }
+
+// Shutdown is a no-op since the test provider holds no external resources.
+func (p *testProvider) Shutdown(bool) error { return nil }
+
+// removeCluster deletes the cluster from the member list and broadcasts the
+// change. Tests use it to simulate a node failure.
+func (p *testProvider) removeCluster(c *Cluster) {
+	host, port, _ := c.ActorSystem.GetHostPort()
+	id := fmt.Sprintf("%s@%s:%d", c.Config.Name, host, port)
+	p.mu.Lock()
+	delete(p.members, id)
+	p.mu.Unlock()
+	p.publish()
+}
+
+// membershipRecovery restarts a previously stopped cluster node and
+// re-registers it with the test provider to mimic a recovered member.
+func membershipRecovery(c *Cluster) {
+	c.StartMember()
+}
+
+// TestCluster_MembershipRecovery verifies member list and routing behaviour
+// when a node goes down and later rejoins the cluster.
+func TestCluster_MembershipRecovery(t *testing.T) {
+	prov := newTestProvider()
+	kind := NewKind("echo", actor.PropsFromFunc(func(ctx actor.Context) {
+		if _, ok := ctx.Message().(*emptypb.Empty); ok {
+			ctx.Respond(&emptypb.Empty{})
+		}
+	}))
+
+	c1 := newClusterForTest("node1", prov, WithKinds(kind))
+	c2 := newClusterForTest("node2", prov, WithKinds(kind))
+
+	c1.StartMember()
+	c2.StartMember()
+
+	// spawn echo actor on second node and cache its PID in the first
+	pid2, err := c2.ActorSystem.Root.SpawnNamed(kind.Props, "echo")
+	assert.NoError(t, err)
+	c1.PidCache.Set("echo", "echo", pid2)
+
+	fut := c1.ActorSystem.Root.RequestFuture(pid2, &emptypb.Empty{}, time.Second)
+	res, err := fut.Result()
+	assert.NoError(t, err)
+	_, ok := res.(*emptypb.Empty)
+	assert.True(t, ok)
+
+	// simulate node loss
+	prov.removeCluster(c2)
+	c2.Shutdown(true)
+
+	fut = c1.ActorSystem.Root.RequestFuture(pid2, &emptypb.Empty{}, 200*time.Millisecond)
+	_, err = fut.Result()
+	assert.Error(t, err)
+	assert.Equal(t, 1, c1.MemberList.Length())
+
+	// node recovers with a fresh cluster instance
+	c2a := newClusterForTest("node2", prov, WithKinds(kind))
+	membershipRecovery(c2a)
+	pid2a, err := c2a.ActorSystem.Root.SpawnNamed(kind.Props, "echo")
+	assert.NoError(t, err)
+	c1.PidCache.Set("echo", "echo", pid2a)
+
+	fut = c1.ActorSystem.Root.RequestFuture(pid2a, &emptypb.Empty{}, time.Second)
+	res, err = fut.Result()
+	assert.NoError(t, err)
+	_, ok = res.(*emptypb.Empty)
+	assert.True(t, ok)
+	assert.Equal(t, 2, c1.MemberList.Length())
+}

--- a/remote/reconnect_test.go
+++ b/remote/reconnect_test.go
@@ -1,0 +1,66 @@
+package remote
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/emptypb"
+)
+
+// simulatePartition stops the given remote server to mimic a network partition.
+func simulatePartition(r *Remote) {
+	r.Shutdown(true)
+}
+
+// reconnectRemote starts the provided remote server after a partition.
+func reconnectRemote(r *Remote) {
+	r.Start()
+}
+
+// TestRemote_ReconnectAfterPartition starts a remote node, shuts it down to
+// simulate a partition, and verifies communication after a new node comes back.
+func TestRemote_ReconnectAfterPartition(t *testing.T) {
+	systemA := actor.NewActorSystem()
+	remoteA := NewRemote(systemA, Configure("127.0.0.1", 0))
+	remoteA.Start()
+	defer remoteA.Shutdown(true)
+
+	// initial remote node
+	systemB := actor.NewActorSystem()
+	remoteB := NewRemote(systemB, Configure("127.0.0.1", 0))
+	remoteB.Start()
+
+	props := actor.PropsFromFunc(func(ctx actor.Context) {
+		if _, ok := ctx.Message().(*emptypb.Empty); ok {
+			ctx.Respond(&emptypb.Empty{})
+		}
+	})
+	pid1, err := systemB.Root.SpawnNamed(props, "echo1")
+	assert.NoError(t, err)
+
+	fut := systemA.Root.RequestFuture(pid1, &emptypb.Empty{}, time.Second)
+	_, err = fut.Result()
+	assert.NoError(t, err)
+
+	// partition the first node
+	simulatePartition(remoteB)
+
+	fut = systemA.Root.RequestFuture(pid1, &emptypb.Empty{}, 200*time.Millisecond)
+	_, err = fut.Result()
+	assert.Error(t, err)
+
+	// bring up a new remote node
+	systemB2 := actor.NewActorSystem()
+	remoteB2 := NewRemote(systemB2, Configure("127.0.0.1", 0))
+	reconnectRemote(remoteB2)
+	defer remoteB2.Shutdown(true)
+
+	pid2, err := systemB2.Root.SpawnNamed(props, "echo2")
+	assert.NoError(t, err)
+
+	fut = systemA.Root.RequestFuture(pid2, &emptypb.Empty{}, time.Second)
+	_, err = fut.Result()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- add remote reconnection test with simulatePartition and reconnectRemote helpers
- add cluster membership recovery test with membershipRecovery helper
- document test-only provider and recovery helpers for maintainers

## Testing
- `go test ./remote -run TestRemote_ReconnectAfterPartition -count=1`
- `go test ./cluster -run TestCluster_MembershipRecovery -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689ccf4c6e2c8328bf6e224361c6932f