### PR TITLE
test: verify cluster identity for virtual actors

### DIFF
--- a/cluster/cluster_identity.go
+++ b/cluster/cluster_identity.go
@@ -32,7 +32,12 @@ func (ci *ClusterIdentity) ExtensionID() ctxext.ContextExtensionID {
 
 // GetClusterIdentity retrieves the ClusterIdentity from the context.
 func GetClusterIdentity(ctx actor.ExtensionContext) *ClusterIdentity {
-	return ctx.Get(ciExtensionId).(*ClusterIdentity)
+	if ext := ctx.Get(ciExtensionId); ext != nil {
+		if ci, ok := ext.(*ClusterIdentity); ok {
+			return ci
+		}
+	}
+	return nil
 }
 
 // SetClusterIdentity stores the ClusterIdentity on the context.

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -89,7 +89,8 @@ func (l *fakeIdentityLookup) Get(identity *ClusterIdentity) *actor.PID {
 	// if the kind is registered, spawn the actor on first lookup
 	if l.cluster != nil {
 		if kind := l.cluster.GetClusterKind(identity.Kind); kind != nil {
-			pid, err := l.cluster.ActorSystem.Root.SpawnNamed(kind.Props, identity.Identity)
+			props := WithClusterIdentity(kind.Props, identity)
+			pid, err := l.cluster.ActorSystem.Root.SpawnNamed(props, identity.Identity)
 			if err == nil {
 				l.m.Store(identity.Identity, pid)
 				return pid

--- a/cluster/grain_context_test.go
+++ b/cluster/grain_context_test.go
@@ -1,0 +1,54 @@
+package cluster
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that a virtual actor (cluster kind) can access its ClusterIdentity via the
+// context extension and also obtain the Cluster instance.
+func TestVirtualActorContextHasClusterIdentity(t *testing.T) {
+	cp := newInmemoryProvider()
+	identityCh := make(chan *ClusterIdentity, 1)
+	clusterCh := make(chan *Cluster, 1)
+
+	kindName := "kind"
+	actorID := "myactor"
+
+	// Actor stores the ClusterIdentity and Cluster when it receives the
+	// system generated ClusterInit message.
+	kind := NewKind(kindName, actor.PropsFromFunc(func(ctx actor.Context) {
+		switch ctx.Message().(type) {
+		case *ClusterInit:
+			identityCh <- GetClusterIdentity(ctx)
+			clusterCh <- GetCluster(ctx.ActorSystem())
+		}
+	}))
+
+	c := newClusterForTest("mycluster", cp, WithKinds(kind))
+	c.StartMember()
+	cp.publishClusterTopologyEvent()
+
+	pid := c.Get(actorID, kindName)
+	assert.NotNil(t, pid)
+
+	select {
+	case ci := <-identityCh:
+		assert.NotNil(t, ci)
+		assert.Equal(t, actorID, ci.Identity)
+		assert.Equal(t, kindName, ci.Kind)
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for ClusterIdentity")
+	}
+
+	select {
+	case cl := <-clusterCh:
+		assert.NotNil(t, cl)
+		assert.Equal(t, c, cl)
+	case <-time.After(time.Second):
+		t.Fatalf("timeout waiting for Cluster instance")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure GetClusterIdentity is nil-safe
- confirm virtual actors expose ClusterIdentity and Cluster via context

## Testing
- `go test ./cluster -run TestVirtualActorContextHasClusterIdentity -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_689ce34328688328892220b4ce629a7b