### PR TITLE
docs: add Consul startup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Instructions
+
+## Consul requirement for tests
+
+Some test packages require a local Consul agent. Start Consul in dev mode before running these tests:
+
+```bash
+# install Consul if needed
+CONSUL_VERSION=1.21.4
+curl -sLo /tmp/consul.zip https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip
+unzip -o /tmp/consul.zip -d /usr/local/bin
+
+# start Consul in dev mode
+consul agent -dev > /tmp/consul.log 2>&1 &
+
+# verify
+curl -s localhost:8500/v1/status/leader
+```
+
+With Consul running, you can execute the test suites:
+
+```bash
+curl -s localhost:8500/v1/status/leader
+go test ./cluster/... -count=1
+go test ./scheduler -run TestNewTimerScheduler -v
+go test ./remote/... -count=1
+go test ./persistence/... -count=1
+```


### PR DESCRIPTION
## Summary
- document starting a Consul agent for tests and list required test commands

## Testing
- `curl -s localhost:8500/v1/status/leader`
- `go test $(go list ./cluster/... | grep -v clusterproviders/etcd | grep -v clusterproviders/zk) -count=1`
- `go test ./scheduler -run TestNewTimerScheduler -v`
- `go test ./remote/... -count=1`
- `go test ./persistence/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689ceced28148328828fc351becbe43a