### PR TITLE
refactor: address cluster lint warnings

### DIFF
--- a/cluster/clusterproviders/consul/consul_provider.go
+++ b/cluster/clusterproviders/consul/consul_provider.go
@@ -71,7 +71,7 @@ func NewWithConfig(consulConfig *api.Config, opts ...Option) (*Provider, error) 
 func (p *Provider) init(c *cluster.Cluster) error {
 	knownKinds := c.GetClusterKinds()
 	clusterName := c.Config.Name
-	memberId := c.ActorSystem.ID
+	memberID := c.ActorSystem.ID
 
 	host, port, err := c.ActorSystem.GetHostPort()
 	if err != nil {
@@ -79,7 +79,7 @@ func (p *Provider) init(c *cluster.Cluster) error {
 	}
 
 	p.cluster = c
-	p.id = memberId
+	p.id = memberID
 	p.clusterName = clusterName
 	p.address = host
 	p.port = port
@@ -127,7 +127,7 @@ func (p *Provider) DeregisterMember() error {
 }
 
 // Shutdown stops the provider and its internal actor.
-func (p *Provider) Shutdown(graceful bool) error {
+func (p *Provider) Shutdown(_ bool) error {
 	if p.shutdown {
 		return nil
 	}
@@ -190,13 +190,13 @@ func (p *Provider) notifyStatuses() {
 	var members []*cluster.Member
 	for _, v := range statuses {
 		if len(v.Checks) > 0 && v.Checks.AggregatedStatus() == api.HealthPassing {
-			memberId := v.Service.Meta["id"]
-			if memberId == "" {
-				memberId = fmt.Sprintf("%v@%v:%v", p.clusterName, v.Service.Address, v.Service.Port)
-				p.cluster.Logger().Info("meta['id'] was empty, fixeds", slog.String("id", memberId))
+			memberID := v.Service.Meta["id"]
+			if memberID == "" {
+				memberID = fmt.Sprintf("%v@%v:%v", p.clusterName, v.Service.Address, v.Service.Port)
+				p.cluster.Logger().Info("meta['id'] was empty, fixeds", slog.String("id", memberID))
 			}
 			members = append(members, &cluster.Member{
-				Id:    memberId,
+				Id:    memberID,
 				Host:  v.Service.Address,
 				Port:  int32(v.Service.Port),
 				Kinds: v.Service.Tags,

--- a/cluster/clusterproviders/consul/provider_actor.go
+++ b/cluster/clusterproviders/consul/provider_actor.go
@@ -1,3 +1,4 @@
+// Package consul provides a Consul-based cluster provider.
 package consul
 
 import (
@@ -112,13 +113,13 @@ func (pa *providerActor) processConsulUpdate(index uint64, result interface{}, c
 	var members []*cluster.Member
 	for _, v := range serviceEntries {
 		if len(v.Checks) > 0 && v.Checks.AggregatedStatus() == api.HealthPassing {
-			memberId := v.Service.Meta["id"]
-			if memberId == "" {
-				memberId = fmt.Sprintf("%v@%v:%v", pa.clusterName, v.Service.Address, v.Service.Port)
-				ctx.Logger().Info("meta['id'] was empty, fixed", slog.String("id", memberId))
+			memberID := v.Service.Meta["id"]
+			if memberID == "" {
+				memberID = fmt.Sprintf("%v@%v:%v", pa.clusterName, v.Service.Address, v.Service.Port)
+				ctx.Logger().Info("meta['id'] was empty, fixed", slog.String("id", memberID))
 			}
 			members = append(members, &cluster.Member{
-				Id:    memberId,
+				Id:    memberID,
 				Host:  v.Service.Address,
 				Port:  int32(v.Service.Port),
 				Kinds: v.Service.Tags,

--- a/cluster/clusterproviders/etcd/etcd_provider.go
+++ b/cluster/clusterproviders/etcd/etcd_provider.go
@@ -1,3 +1,4 @@
+// Package etcd provides an etcd-based cluster provider.
 package etcd
 
 import (
@@ -135,7 +136,7 @@ func (p *Provider) StartClient(c *cluster.Cluster) error {
 }
 
 // Shutdown deregisters the node and stops background tasks.
-func (p *Provider) Shutdown(graceful bool) error {
+func (p *Provider) Shutdown(_ bool) error {
 	p.shutdown = true
 	if !p.deregistered {
 		p.updateLeadership()
@@ -153,7 +154,7 @@ func (p *Provider) Shutdown(graceful bool) error {
 	return nil
 }
 
-func (p *Provider) keepAliveForever(ctx context.Context) error {
+func (p *Provider) keepAliveForever(_ context.Context) error {
 	if p.self == nil {
 		return fmt.Errorf("keepalive must be after initialize")
 	}
@@ -164,21 +165,21 @@ func (p *Provider) keepAliveForever(ctx context.Context) error {
 	}
 	fullKey := p.getEtcdKey()
 
-	var leaseId clientv3.LeaseID
-	leaseId, err = p.newLeaseID()
+	var leaseID clientv3.LeaseID
+	leaseID, err = p.newLeaseID()
 	if err != nil {
 		return err
 	}
-	p.setLeaseID(leaseId)
+	p.setLeaseID(leaseID)
 
-	if leaseId <= 0 {
-		return fmt.Errorf("grant lease failed. leaseId=%d", leaseId)
+	if leaseID <= 0 {
+		return fmt.Errorf("grant lease failed. leaseID=%d", leaseID)
 	}
-	_, err = p.client.Put(context.TODO(), fullKey, string(data), clientv3.WithLease(leaseId))
+	_, err = p.client.Put(context.TODO(), fullKey, string(data), clientv3.WithLease(leaseID))
 	if err != nil {
 		return err
 	}
-	kaRespCh, err := p.client.KeepAlive(context.TODO(), leaseId)
+	kaRespCh, err := p.client.KeepAlive(context.TODO(), leaseID)
 	if err != nil {
 		return err
 	}
@@ -228,16 +229,16 @@ func (p *Provider) registerService() error {
 	if err != nil {
 		return err
 	}
-	leaseId := p.getLeaseID()
-	if leaseId <= 0 {
-		_leaseId, err := p.newLeaseID()
+	leaseID := p.getLeaseID()
+	if leaseID <= 0 {
+		_leaseID, err := p.newLeaseID()
 		if err != nil {
 			return err
 		}
-		leaseId = _leaseId
-		p.setLeaseID(leaseId)
+		leaseID = _leaseID
+		p.setLeaseID(leaseID)
 	}
-	_, err = p.client.Put(context.TODO(), fullKey, string(data), clientv3.WithLease(leaseId))
+	_, err = p.client.Put(context.TODO(), fullKey, string(data), clientv3.WithLease(leaseID))
 	if err != nil {
 		return err
 	}
@@ -254,7 +255,7 @@ func (p *Provider) handleWatchResponse(resp clientv3.WatchResponse) map[string]*
 	changes := map[string]*Node{}
 	for _, ev := range resp.Events {
 		key := string(ev.Kv.Key)
-		nodeId, err := getNodeID(key, "/")
+		nodeID, err := getNodeID(key, "/")
 		if err != nil {
 			p.cluster.Logger().Error("Invalid member.", slog.String("key", key))
 			continue
@@ -271,16 +272,16 @@ func (p *Provider) handleWatchResponse(resp clientv3.WatchResponse) map[string]*
 				p.cluster.Logger().Debug("Skip self.", slog.String("key", key))
 				continue
 			}
-			if _, ok := p.members[nodeId]; ok {
+			if _, ok := p.members[nodeID]; ok {
 				p.cluster.Logger().Debug("Update member.", slog.String("key", key))
 			} else {
 				p.cluster.Logger().Debug("New member.", slog.String("key", key))
 			}
-			changes[nodeId] = node
-			node.SetMeta(metaKeySeq, nodeId)
+			changes[nodeID] = node
+			node.SetMeta(metaKeySeq, nodeID)
 			node.SetMeta(metaKeySeq, fmt.Sprintf("%d", ev.Kv.Lease))
 		case clientv3.EventTypeDelete:
-			node, ok := p.members[nodeId]
+			node, ok := p.members[nodeID]
 			if !ok {
 				continue
 			}
@@ -291,8 +292,8 @@ func (p *Provider) handleWatchResponse(resp clientv3.WatchResponse) map[string]*
 			p.cluster.Logger().Debug("Delete member.", slog.String("key", key))
 			cloned := *node
 			cloned.SetAlive(false)
-			changes[nodeId] = &cloned
-			node.SetMeta(metaKeySeq, nodeId)
+			changes[nodeID] = &cloned
+			node.SetMeta(metaKeySeq, nodeID)
 			node.SetMeta(metaKeySeq, fmt.Sprintf("%d", ev.Kv.Lease))
 		default:
 			p.cluster.Logger().Error("Invalid etcd event.type.", slog.String("key", key),
@@ -398,10 +399,10 @@ func (p *Provider) updateNodesWithSelf(members []*Node) {
 }
 
 func (p *Provider) updateNodesWithChanges(changes map[string]*Node) {
-	for memberId, member := range changes {
-		p.members[memberId] = member
+	for memberID, member := range changes {
+		p.members[memberID] = member
 		if !member.IsAlive() {
-			delete(p.members, memberId)
+			delete(p.members, memberID)
 		}
 	}
 }

--- a/cluster/metrics/cluster_metrics.go
+++ b/cluster/metrics/cluster_metrics.go
@@ -21,7 +21,7 @@ func newObservableGauge(meter metric.Meter, name, description string, logger *sl
 	g := &observableGauge{}
 	_, err := meter.Int64ObservableGauge(name,
 		metric.WithDescription(description),
-		metric.WithInt64Callback(func(ctx context.Context, o metric.Int64Observer) error {
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
 			g.mu.RLock()
 			v := g.value
 			g.mu.RUnlock()

--- a/cluster/pubsub_producer.go
+++ b/cluster/pubsub_producer.go
@@ -1,3 +1,4 @@
+// Package cluster provides clustering primitives such as a batching pub/sub producer.
 package cluster
 
 import (
@@ -15,6 +16,7 @@ import (
 // PublishingErrorHandler decides what to do with a publishing error in BatchingProducer
 type PublishingErrorHandler func(retries int, e error, batch *PubSubBatch) *PublishingErrorDecision
 
+// BatchingProducerConfig configures BatchingProducer behavior.
 type BatchingProducerConfig struct {
 	// Maximum size of the published batch. Default: 2000.
 	BatchSize int
@@ -45,7 +47,7 @@ func newBatchingProducerConfig(logger *slog.Logger, opts ...BatchingProducerConf
 	config := &BatchingProducerConfig{
 		BatchSize:      2000,
 		PublishTimeout: 5 * time.Second,
-		OnPublishingError: func(retries int, e error, batch *PubSubBatch) *PublishingErrorDecision {
+		OnPublishingError: func(_ int, _ error, _ *PubSubBatch) *PublishingErrorDecision {
 			return FailBatchAndStop
 		},
 		LogThrottle: actor.NewThrottleWithLogger(logger, 10, time.Second, func(logger *slog.Logger, i int32) {
@@ -60,6 +62,7 @@ func newBatchingProducerConfig(logger *slog.Logger, opts ...BatchingProducerConf
 	return config
 }
 
+// BatchingProducer publishes messages in batches to reduce network overhead.
 type BatchingProducer struct {
 	config           *BatchingProducerConfig
 	topic            string
@@ -70,6 +73,7 @@ type BatchingProducer struct {
 	msgLeft          uint32
 }
 
+// NewBatchingProducer creates a producer that batches messages before publishing.
 func NewBatchingProducer(publisher Publisher, topic string, opts ...BatchingProducerConfigOption) *BatchingProducer {
 	config := newBatchingProducerConfig(publisher.Logger(), opts...)
 	p := &BatchingProducer{
@@ -394,6 +398,7 @@ loop:
 	return nil
 }
 
+// ProducerQueueFullException is returned when the producer queue exceeds its capacity.
 type ProducerQueueFullException struct {
 	topic string
 }
@@ -402,15 +407,18 @@ func (p *ProducerQueueFullException) Error() string {
 	return "Producer for topic " + p.topic + " has full queue"
 }
 
+// Is allows errors.Is checks against ProducerQueueFullException.
 func (p *ProducerQueueFullException) Is(target error) bool {
 	_, ok := target.(*ProducerQueueFullException)
 	return ok
 }
 
+// InvalidOperationException indicates that a method call was made in an invalid state.
 type InvalidOperationException struct {
 	Topic string
 }
 
+// Is allows errors.Is checks against InvalidOperationException.
 func (i *InvalidOperationException) Is(err error) bool {
 	_, ok := err.(*InvalidOperationException)
 	return ok
@@ -543,10 +551,9 @@ func (u *unboundedChannel[T]) tryRead() (T, bool) {
 	tmp := u.queue.Pop()
 	if tmp == nil {
 		return msg, false
-	} else {
-		u.cond.Broadcast()
-		return tmp.(T), true
 	}
+	u.cond.Broadcast()
+	return tmp.(T), true
 }
 
 //lint:ignore U1000 used via interface


### PR DESCRIPTION
## Summary
- document and tidy batching producer
- clean up Consul provider naming and unused parameters
- fix etcd provider variable naming and add package comments

## Testing
- `curl -s localhost:8500/v1/status/leader`
- `go test ./cluster/... -count=1`
- `go test ./scheduler -run TestNewTimerScheduler -v`
- `go test ./remote/... -count=1`
- `go test ./persistence/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_689e4783212c8328bf00b1cdaab7e8e9