### PR TITLE
Add TestKit utilities for actor testing

### DIFF
--- a/testkit/testmailboxstats.go
+++ b/testkit/testmailboxstats.go
@@ -1,0 +1,46 @@
+package testkit
+
+import "github.com/asynkron/protoactor-go/actor"
+
+// TestMailboxStats collects mailbox events for tests.
+type TestMailboxStats struct {
+	waitForReceived func(interface{}) bool
+	Reset           chan struct{}
+	Stats           []interface{}
+	Posted          []interface{}
+	Received        []interface{}
+}
+
+// NewTestMailboxStats creates a new stats collector.
+func NewTestMailboxStats(wait func(interface{}) bool) *TestMailboxStats {
+	return &TestMailboxStats{
+		waitForReceived: wait,
+		Reset:           make(chan struct{}, 1),
+	}
+}
+
+// MailboxStarted records the start event.
+func (t *TestMailboxStats) MailboxStarted() { t.Stats = append(t.Stats, "Started") }
+
+// MessagePosted records a posted message.
+func (t *TestMailboxStats) MessagePosted(message interface{}) {
+	t.Stats = append(t.Stats, message)
+	t.Posted = append(t.Posted, message)
+}
+
+// MessageReceived records a received message and signals if predicate matches.
+func (t *TestMailboxStats) MessageReceived(message interface{}) {
+	t.Stats = append(t.Stats, message)
+	t.Received = append(t.Received, message)
+	if t.waitForReceived != nil && t.waitForReceived(message) {
+		select {
+		case t.Reset <- struct{}{}:
+		default:
+		}
+	}
+}
+
+// MailboxEmpty records an empty mailbox event.
+func (t *TestMailboxStats) MailboxEmpty() { t.Stats = append(t.Stats, "Empty") }
+
+var _ actor.MailboxMiddleware = (*TestMailboxStats)(nil)

--- a/testkit/testmailboxstats_test.go
+++ b/testkit/testmailboxstats_test.go
@@ -1,0 +1,30 @@
+package testkit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMailboxStatsCapturesMessages(t *testing.T) {
+	system := actor.NewActorSystem()
+	stats := NewTestMailboxStats(func(msg interface{}) bool { return msg == "hi" })
+	props := actor.PropsFromFunc(func(ctx actor.Context) {}, actor.WithMailbox(actor.Unbounded(stats)))
+	pid := system.Root.Spawn(props)
+
+	system.Root.Send(pid, "hi")
+	select {
+	case <-stats.Reset:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	require.Len(t, stats.Posted, 2)
+	require.Equal(t, "hi", stats.Posted[1])
+	require.Len(t, stats.Received, 2)
+	require.Equal(t, "hi", stats.Received[1])
+}

--- a/testkit/testprobe.go
+++ b/testkit/testprobe.go
@@ -1,0 +1,164 @@
+package testkit
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+)
+
+// messageAndSender captures a message and its sender.
+type messageAndSender struct {
+	message interface{}
+	sender  *actor.PID
+}
+
+// TestProbe is an actor used in tests to intercept and assert on messages.
+// It stores every incoming message along with its sender.
+type TestProbe struct {
+	ch     chan messageAndSender
+	ctx    actor.Context
+	sender *actor.PID
+}
+
+// NewTestProbe creates a new TestProbe instance.
+func NewTestProbe() *TestProbe {
+	return &TestProbe{ch: make(chan messageAndSender, 100)}
+}
+
+// Receive implements actor.Actor. It records all messages after initialization.
+func (tp *TestProbe) Receive(ctx actor.Context) {
+	switch ctx.Message().(type) {
+	case *actor.Started:
+		tp.ctx = ctx
+	default:
+		tp.ch <- messageAndSender{message: ctx.Message(), sender: ctx.Sender()}
+	}
+}
+
+// Context returns the probe's context. Panics if called before Start.
+func (tp *TestProbe) Context() actor.Context {
+	if tp.ctx == nil {
+		panic("probe context is nil")
+	}
+	return tp.ctx
+}
+
+// Sender returns the sender of the last retrieved message.
+func (tp *TestProbe) Sender() *actor.PID { return tp.sender }
+
+// ExpectNoMessage verifies that no message arrives within the allowed time.
+func (tp *TestProbe) ExpectNoMessage(timeAllowed time.Duration) error {
+	if timeAllowed == 0 {
+		timeAllowed = time.Second
+	}
+	select {
+	case m := <-tp.ch:
+		return fmt.Errorf("waited %v and received message of type %T", timeAllowed, m.message)
+	case <-time.After(timeAllowed):
+		return nil
+	}
+}
+
+// GetNextMessage waits for the next message and returns it.
+func (tp *TestProbe) GetNextMessage(timeAllowed time.Duration) (interface{}, error) {
+	if timeAllowed == 0 {
+		timeAllowed = time.Second
+	}
+	select {
+	case m := <-tp.ch:
+		tp.sender = m.sender
+		return m.message, nil
+	case <-time.After(timeAllowed):
+		return nil, fmt.Errorf("waited %v but failed to receive a message", timeAllowed)
+	}
+}
+
+// Send forwards a message to the target actor.
+func (tp *TestProbe) Send(target *actor.PID, message interface{}) { tp.Context().Send(target, message) }
+
+// Request sends a request message from the probe to the target.
+func (tp *TestProbe) Request(target *actor.PID, message interface{}) {
+	tp.Context().Request(target, message)
+}
+
+// Respond sends a response to the last sender if present.
+func (tp *TestProbe) Respond(message interface{}) {
+	if tp.sender != nil {
+		tp.Send(tp.sender, message)
+	}
+}
+
+// Helper functions -------------------------------------------------------
+
+// GetNextMessageOf waits for the next message and asserts its type.
+func GetNextMessageOf[T any](tp *TestProbe, timeAllowed time.Duration) (T, error) {
+	var zero T
+	msg, err := tp.GetNextMessage(timeAllowed)
+	if err != nil {
+		return zero, err
+	}
+	typed, ok := msg.(T)
+	if !ok {
+		return zero, fmt.Errorf("message expected type %T, actual type %T", zero, msg)
+	}
+	return typed, nil
+}
+
+// GetNextMessageWhere waits for the next message of type T matching the predicate.
+func GetNextMessageWhere[T any](tp *TestProbe, when func(T) bool, timeAllowed time.Duration) (T, error) {
+	msg, err := GetNextMessageOf[T](tp, timeAllowed)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	if !when(msg) {
+		var zero T
+		return zero, errors.New("condition not met")
+	}
+	return msg, nil
+}
+
+// FishForMessage waits until a message of type T arrives that satisfies when.
+func FishForMessage[T any](tp *TestProbe, when func(T) bool, timeAllowed time.Duration) (T, error) {
+	var zero T
+	if timeAllowed == 0 {
+		timeAllowed = time.Second
+	}
+	deadline := time.Now().Add(timeAllowed)
+	for time.Now().Before(deadline) {
+		remaining := time.Until(deadline)
+		select {
+		case m := <-tp.ch:
+			if typed, ok := m.message.(T); ok && when(typed) {
+				tp.sender = m.sender
+				return typed, nil
+			}
+		case <-time.After(remaining):
+			return zero, errors.New("message not found")
+		}
+	}
+	return zero, errors.New("message not found")
+}
+
+// FishForMessageOf waits for any message of type T.
+func FishForMessageOf[T any](tp *TestProbe, timeAllowed time.Duration) (T, error) {
+	return FishForMessage(tp, func(T) bool { return true }, timeAllowed)
+}
+
+// RequestFuture sends a request and waits for a typed response.
+func RequestFuture[T any](tp *TestProbe, target *actor.PID, message interface{}, timeout time.Duration) (T, error) {
+	var zero T
+	res, err := tp.Context().RequestFuture(target, message, timeout).Result()
+	if err != nil {
+		return zero, err
+	}
+	typed, ok := res.(T)
+	if !ok {
+		return zero, fmt.Errorf("message expected type %T, actual type %T", zero, res)
+	}
+	return typed, nil
+}
+
+// implicit PID conversion is not available in Go; use tp.Context().Self() for the probe PID.

--- a/testkit/testprobe_test.go
+++ b/testkit/testprobe_test.go
@@ -1,0 +1,59 @@
+package testkit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProbeGetNextMessage(t *testing.T) {
+	system := actor.NewActorSystem()
+	probe := NewTestProbe()
+	pid := system.Root.Spawn(actor.PropsFromProducer(func() actor.Actor { return probe }))
+
+	system.Root.Send(pid, "hello")
+	msg, err := GetNextMessageOf[string](probe, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "hello", msg)
+}
+
+func TestProbeFishForMessage(t *testing.T) {
+	system := actor.NewActorSystem()
+	probe := NewTestProbe()
+	pid := system.Root.Spawn(actor.PropsFromProducer(func() actor.Actor { return probe }))
+
+	system.Root.Send(pid, "a")
+	system.Root.Send(pid, "b")
+	msg, err := FishForMessage(probe, func(s string) bool { return s == "b" }, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "b", msg)
+}
+
+func TestProbeSender(t *testing.T) {
+	system := actor.NewActorSystem()
+	probe := NewTestProbe()
+	probePID := system.Root.Spawn(actor.PropsFromProducer(func() actor.Actor { return probe }))
+
+	sender := system.Root.Spawn(actor.PropsFromFunc(func(ctx actor.Context) {
+		ctx.Request(probePID, "hi")
+	}))
+
+	msg, err := GetNextMessageOf[string](probe, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "hi", msg)
+	require.Equal(t, sender, probe.Sender())
+}
+
+func TestProbeExpectNoMessage(t *testing.T) {
+	system := actor.NewActorSystem()
+	probe := NewTestProbe()
+	pid := system.Root.Spawn(actor.PropsFromProducer(func() actor.Actor { return probe }))
+
+	require.NoError(t, probe.ExpectNoMessage(50*time.Millisecond))
+
+	system.Root.Send(pid, "hi")
+	err := probe.ExpectNoMessage(50 * time.Millisecond)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- add TestProbe actor for intercepting and asserting messages
- add TestMailboxStats to track mailbox events

## Testing
- `go test ./testkit -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a75a0a22348328837e8f114a64d759