### PR TITLE
Add props extensions for TestMailboxStats

### DIFF
--- a/examples/actor.testkit/actor_testkit_example_test.go
+++ b/examples/actor.testkit/actor_testkit_example_test.go
@@ -1,0 +1,115 @@
+package actortestkit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+	"github.com/asynkron/protoactor-go/testkit"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUsingTestProbe shows how to interact with actors via TestProbe.
+func TestUsingTestProbe(t *testing.T) {
+	system := actor.NewActorSystem()
+
+	// Spawn the probe as an actor in the system and wait for it to be ready.
+	probe := testkit.NewTestProbe()
+	probePID := system.Root.Spawn(actor.PropsFromProducer(func() actor.Actor { return probe }))
+	system.Root.Send(probePID, "ready")
+	_, err := testkit.GetNextMessageOf[string](probe, time.Second)
+	require.NoError(t, err)
+
+	// Echo actor replies with "pong" to any string message.
+	echoProps := actor.PropsFromFunc(func(ctx actor.Context) {
+		if msg, ok := ctx.Message().(string); ok {
+			ctx.Respond("pong: " + msg)
+		}
+	})
+	echoPID := system.Root.Spawn(echoProps)
+
+	// Use the probe to send a request and assert on the response.
+	probe.Request(echoPID, "ping")
+	reply, err := testkit.GetNextMessageOf[string](probe, time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "pong: ping", reply)
+
+	// Ensure no unexpected messages arrive.
+	require.NoError(t, probe.ExpectNoMessage(50*time.Millisecond))
+}
+
+// TestUsingTestMailboxStats demonstrates capturing mailbox activity.
+func TestUsingTestMailboxStats(t *testing.T) {
+	system := actor.NewActorSystem()
+
+	// Collect mailbox events and signal when "done" is received.
+	stats := testkit.NewTestMailboxStats(func(msg interface{}) bool { return msg == "done" })
+	// Attach the collector directly to the mailbox via props.
+	props := actor.PropsFromFunc(func(ctx actor.Context) {}, testkit.WithMailboxStats(stats))
+	pid := system.Root.Spawn(props)
+
+	// Send a message and wait until it is processed.
+	system.Root.Send(pid, "done")
+	select {
+	case <-stats.Reset:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+
+	// Allow time for mailbox events to be recorded.
+	time.Sleep(50 * time.Millisecond)
+
+	// The first posted/received message is *actor.Started; the second is our message.
+	require.Len(t, stats.Posted, 2)
+	require.Equal(t, "done", stats.Posted[1])
+	require.Len(t, stats.Received, 2)
+	require.Equal(t, "done", stats.Received[1])
+}
+
+// TestMailboxStatsAsReceiverMiddleware shows using stats as a receive middleware.
+func TestMailboxStatsAsReceiverMiddleware(t *testing.T) {
+	system := actor.NewActorSystem()
+
+	// Signal when "done" is observed by the middleware.
+	stats := testkit.NewTestMailboxStats(func(msg interface{}) bool { return msg == "done" })
+	props := actor.PropsFromFunc(func(ctx actor.Context) {}, testkit.WithReceiveStats(stats))
+	pid := system.Root.Spawn(props)
+
+	// Trigger the actor and wait for the middleware to see the message.
+	system.Root.Send(pid, "done")
+	select {
+	case <-stats.Reset:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for message")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	// *actor.Started is first, followed by our message.
+	require.Len(t, stats.Received, 2)
+	require.Equal(t, "done", stats.Received[1])
+}
+
+// TestMailboxStatsAsSendMiddleware shows using stats as a send middleware.
+func TestMailboxStatsAsSendMiddleware(t *testing.T) {
+	system := actor.NewActorSystem()
+
+	// No wait predicate needed as we inspect Posted after the fact.
+	stats := testkit.NewTestMailboxStats(nil)
+	props := actor.PropsFromFunc(func(ctx actor.Context) {
+		if msg, ok := ctx.Message().(string); ok && msg == "start" {
+			ctx.Respond("done")
+		}
+	}, testkit.WithSendStats(stats))
+	pid := system.Root.Spawn(props)
+
+	// Request a response to trigger sending.
+	res, err := system.Root.RequestFuture(pid, "start", time.Second).Result()
+	require.NoError(t, err)
+	require.Equal(t, "done", res)
+
+	time.Sleep(50 * time.Millisecond)
+
+	require.Len(t, stats.Posted, 1)
+	require.Equal(t, "done", stats.Posted[0])
+}

--- a/testkit/testmailboxstats.go
+++ b/testkit/testmailboxstats.go
@@ -44,3 +44,44 @@ func (t *TestMailboxStats) MessageReceived(message interface{}) {
 func (t *TestMailboxStats) MailboxEmpty() { t.Stats = append(t.Stats, "Empty") }
 
 var _ actor.MailboxMiddleware = (*TestMailboxStats)(nil)
+
+// ReceiverMiddleware converts the stats collector into a receiver middleware.
+// Every received message is recorded before being passed on.
+func (t *TestMailboxStats) ReceiverMiddleware() actor.ReceiverMiddleware {
+	return func(next actor.ReceiverFunc) actor.ReceiverFunc {
+		return func(ctx actor.ReceiverContext, envelope *actor.MessageEnvelope) {
+			if envelope != nil {
+				t.MessageReceived(envelope.Message)
+			}
+			next(ctx, envelope)
+		}
+	}
+}
+
+// SenderMiddleware converts the stats collector into a sender middleware.
+// Each sent message is recorded before being forwarded.
+func (t *TestMailboxStats) SenderMiddleware() actor.SenderMiddleware {
+	return func(next actor.SenderFunc) actor.SenderFunc {
+		return func(ctx actor.SenderContext, target *actor.PID, env *actor.MessageEnvelope) {
+			if env != nil {
+				t.MessagePosted(env.Message)
+			}
+			next(ctx, target, env)
+		}
+	}
+}
+
+// WithMailboxStats configures props with a mailbox that records stats.
+func WithMailboxStats(stats *TestMailboxStats) actor.PropsOption {
+	return actor.WithMailbox(actor.Unbounded(stats))
+}
+
+// WithReceiveStats applies the stats collector as a receive middleware.
+func WithReceiveStats(stats *TestMailboxStats) actor.PropsOption {
+	return actor.WithReceiverMiddleware(stats.ReceiverMiddleware())
+}
+
+// WithSendStats applies the stats collector as a send middleware.
+func WithSendStats(stats *TestMailboxStats) actor.PropsOption {
+	return actor.WithSenderMiddleware(stats.SenderMiddleware())
+}


### PR DESCRIPTION
## Summary
- extend TestMailboxStats with receiver and sender middleware helpers
- add WithMailboxStats/WithReceiveStats/WithSendStats props options
- expand actor_testkit example to demonstrate new props extensions

## Testing
- `go test ./testkit -v`
- `go test ./examples/actor.testkit -v`


------
https://chatgpt.com/codex/tasks/task_e_68a7608ac62483288e4824871c4b8e36