### PR TITLE
refactor: make remote metrics test deterministic

### DIFF
--- a/remote/tests/remote_metrics_test.go
+++ b/remote/tests/remote_metrics_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/asynkron/protoactor-go/actor"
 	remote "github.com/asynkron/protoactor-go/remote"
+	"github.com/asynkron/protoactor-go/testkit"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -37,13 +38,18 @@ func TestRemoteMetrics(t *testing.T) {
 
 	system2 := newSystem(provider)
 	remote2 := remote.NewRemote(system2, remote.Configure("127.0.0.1", 0))
+	// collect mailbox stats to determine when the request is handled
+	stats := testkit.NewTestMailboxStats(func(m interface{}) bool {
+		_, ok := m.(*remote.ActorPidRequest)
+		return ok
+	})
 	remote2.Register("echo", actor.PropsFromFunc(func(ctx actor.Context) {
 		switch ctx.Message().(type) {
 		case *remote.ActorPidRequest:
 			// no-op
 			return
 		}
-	}))
+	}, testkit.WithReceiveStats(stats)))
 	remote2.Start()
 	defer system2.Shutdown()
 
@@ -56,7 +62,7 @@ func TestRemoteMetrics(t *testing.T) {
 	}
 
 	system1.Root.Send(resp.Pid, &remote.ActorPidRequest{})
-	time.Sleep(100 * time.Millisecond)
+	<-stats.Reset // wait for the remote actor to handle the request
 
 	remote1.Shutdown(true)
 	remote2.Shutdown(true)


### PR DESCRIPTION
## Summary
- avoid flakiness in remote metrics test by waiting for ActorPidRequest handling
- collect mailbox stats and register echo actor with receive stats middleware
- drop fixed sleep and wait on stats.Reset for deterministic synchronization

## Testing
- `curl -s localhost:8500/v1/status/leader`
- `go test ./remote/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68a76ecc45748328a74334beb510109e