### PR TITLE
feat(testkit): add await condition and cluster helpers

### DIFF
--- a/testkit/await.go
+++ b/testkit/await.go
@@ -1,0 +1,39 @@
+package testkit
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+var pollInterval = 20 * time.Millisecond
+
+// AwaitCondition repeatedly evaluates condition until it returns true or the timeout elapses.
+// If the timeout is reached, an error is returned. An optional message overrides the default error text.
+func AwaitCondition(ctx context.Context, condition func() bool, timeout time.Duration, message ...string) error {
+	if timeout <= 0 {
+		timeout = time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for {
+		if condition() {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			if len(message) > 0 {
+				return errors.New(message[0])
+			}
+			return fmt.Errorf("condition was not met within %v", timeout)
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// AwaitConditionAsync is a convenience wrapper using a background context.
+func AwaitConditionAsync(condition func() bool, timeout time.Duration, message ...string) error {
+	return AwaitCondition(context.Background(), condition, timeout, message...)
+}

--- a/testkit/await_test.go
+++ b/testkit/await_test.go
@@ -1,0 +1,23 @@
+package testkit
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAwaitConditionSuccess(t *testing.T) {
+	start := time.Now()
+	err := AwaitConditionAsync(func() bool {
+		return time.Since(start) > 20*time.Millisecond
+	}, time.Second)
+	if err != nil {
+		t.Fatalf("expected no error: %v", err)
+	}
+}
+
+func TestAwaitConditionTimeout(t *testing.T) {
+	err := AwaitConditionAsync(func() bool { return false }, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}

--- a/testkit/cluster_helpers.go
+++ b/testkit/cluster_helpers.go
@@ -1,0 +1,21 @@
+package testkit
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/asynkron/protoactor-go/cluster"
+)
+
+// ExpectMemberToExist waits until the cluster's member list contains the specified member.
+// A default timeout of 10 seconds is used when timeout is zero.
+func ExpectMemberToExist(c *cluster.Cluster, member *cluster.Member, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
+
+	return AwaitCondition(context.Background(), func() bool {
+		return c.MemberList.ContainsMemberID(member.Id)
+	}, timeout, fmt.Sprintf("Member %s was not found within %v", member.Id, timeout))
+}

--- a/testkit/cluster_helpers.go
+++ b/testkit/cluster_helpers.go
@@ -4,18 +4,23 @@ import (
 	"context"
 	"fmt"
 	"time"
-
-	"github.com/asynkron/protoactor-go/cluster"
 )
 
-// ExpectMemberToExist waits until the cluster's member list contains the specified member.
+// memberLister is the minimal interface needed from a cluster's member list.
+// It allows ExpectMemberToExist to be used without importing the cluster package,
+// avoiding import cycles with packages that also use the testkit.
+type memberLister interface {
+	ContainsMemberID(memberID string) bool
+}
+
+// ExpectMemberToExist waits until the supplied member list reports the given member ID.
 // A default timeout of 10 seconds is used when timeout is zero.
-func ExpectMemberToExist(c *cluster.Cluster, member *cluster.Member, timeout time.Duration) error {
+func ExpectMemberToExist(ml memberLister, memberID string, timeout time.Duration) error {
 	if timeout <= 0 {
 		timeout = 10 * time.Second
 	}
 
 	return AwaitCondition(context.Background(), func() bool {
-		return c.MemberList.ContainsMemberID(member.Id)
-	}, timeout, fmt.Sprintf("Member %s was not found within %v", member.Id, timeout))
+		return ml.ContainsMemberID(memberID)
+	}, timeout, fmt.Sprintf("Member %s was not found within %v", memberID, timeout))
 }

--- a/testkit/cluster_helpers_test.go
+++ b/testkit/cluster_helpers_test.go
@@ -19,12 +19,11 @@ func TestExpectMemberToExist(t *testing.T) {
 	members := cluster.Members{member}
 	c.MemberList.UpdateClusterTopology(members)
 
-	if err := ExpectMemberToExist(c, member, time.Second); err != nil {
+	if err := ExpectMemberToExist(c.MemberList, member.Id, time.Second); err != nil {
 		t.Fatalf("expected member to exist: %v", err)
 	}
 
-	missing := &cluster.Member{Id: "missing"}
-	if err := ExpectMemberToExist(c, missing, 50*time.Millisecond); err == nil {
+	if err := ExpectMemberToExist(c.MemberList, "missing", 50*time.Millisecond); err == nil {
 		t.Fatalf("expected error for missing member")
 	}
 }

--- a/testkit/cluster_helpers_test.go
+++ b/testkit/cluster_helpers_test.go
@@ -1,0 +1,30 @@
+package testkit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/asynkron/protoactor-go/actor"
+	"github.com/asynkron/protoactor-go/cluster"
+	"github.com/asynkron/protoactor-go/remote"
+)
+
+func TestExpectMemberToExist(t *testing.T) {
+	sys := actor.NewActorSystem()
+	c := &cluster.Cluster{ActorSystem: sys}
+	c.Remote = remote.NewRemote(sys, remote.Configure("127.0.0.1", 0))
+	c.MemberList = cluster.NewMemberList(c)
+
+	member := &cluster.Member{Id: "node1"}
+	members := cluster.Members{member}
+	c.MemberList.UpdateClusterTopology(members)
+
+	if err := ExpectMemberToExist(c, member, time.Second); err != nil {
+		t.Fatalf("expected member to exist: %v", err)
+	}
+
+	missing := &cluster.Member{Id: "missing"}
+	if err := ExpectMemberToExist(c, missing, 50*time.Millisecond); err == nil {
+		t.Fatalf("expected error for missing member")
+	}
+}

--- a/testkit/testmailboxstats.go
+++ b/testkit/testmailboxstats.go
@@ -1,6 +1,10 @@
 package testkit
 
-import "github.com/asynkron/protoactor-go/actor"
+import (
+	"sync"
+
+	"github.com/asynkron/protoactor-go/actor"
+)
 
 // TestMailboxStats collects mailbox events for tests.
 type TestMailboxStats struct {
@@ -9,6 +13,8 @@ type TestMailboxStats struct {
 	Stats           []interface{}
 	Posted          []interface{}
 	Received        []interface{}
+
+	mu sync.Mutex
 }
 
 // NewTestMailboxStats creates a new stats collector.
@@ -20,18 +26,26 @@ func NewTestMailboxStats(wait func(interface{}) bool) *TestMailboxStats {
 }
 
 // MailboxStarted records the start event.
-func (t *TestMailboxStats) MailboxStarted() { t.Stats = append(t.Stats, "Started") }
+func (t *TestMailboxStats) MailboxStarted() {
+	t.mu.Lock()
+	t.Stats = append(t.Stats, "Started")
+	t.mu.Unlock()
+}
 
 // MessagePosted records a posted message.
 func (t *TestMailboxStats) MessagePosted(message interface{}) {
+	t.mu.Lock()
 	t.Stats = append(t.Stats, message)
 	t.Posted = append(t.Posted, message)
+	t.mu.Unlock()
 }
 
 // MessageReceived records a received message and signals if predicate matches.
 func (t *TestMailboxStats) MessageReceived(message interface{}) {
+	t.mu.Lock()
 	t.Stats = append(t.Stats, message)
 	t.Received = append(t.Received, message)
+	t.mu.Unlock()
 	if t.waitForReceived != nil && t.waitForReceived(message) {
 		select {
 		case t.Reset <- struct{}{}:
@@ -41,7 +55,11 @@ func (t *TestMailboxStats) MessageReceived(message interface{}) {
 }
 
 // MailboxEmpty records an empty mailbox event.
-func (t *TestMailboxStats) MailboxEmpty() { t.Stats = append(t.Stats, "Empty") }
+func (t *TestMailboxStats) MailboxEmpty() {
+	t.mu.Lock()
+	t.Stats = append(t.Stats, "Empty")
+	t.mu.Unlock()
+}
 
 var _ actor.MailboxMiddleware = (*TestMailboxStats)(nil)
 

--- a/testkit/testmailboxstats_test.go
+++ b/testkit/testmailboxstats_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/asynkron/protoactor-go/actor"
 	"github.com/stretchr/testify/require"
+	"sync"
 )
 
 func TestMailboxStatsCapturesMessages(t *testing.T) {
@@ -27,4 +28,23 @@ func TestMailboxStatsCapturesMessages(t *testing.T) {
 	require.Equal(t, "hi", stats.Posted[1])
 	require.Len(t, stats.Received, 2)
 	require.Equal(t, "hi", stats.Received[1])
+}
+
+func TestMailboxStatsConcurrent(t *testing.T) {
+	stats := NewTestMailboxStats(nil)
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(2)
+		go func(v int) {
+			defer wg.Done()
+			stats.MessagePosted(v)
+		}(i)
+		go func(v int) {
+			defer wg.Done()
+			stats.MessageReceived(v)
+		}(i)
+	}
+	wg.Wait()
+	require.Len(t, stats.Posted, 100)
+	require.Len(t, stats.Received, 100)
 }


### PR DESCRIPTION
## Summary
- add AwaitCondition helpers for waiting on async conditions in tests
- ensure TestMailboxStats is concurrency-safe and add helper to expect cluster members
- cover new helpers with tests

## Testing
- `go test ./testkit -count=1`

------
https://chatgpt.com/codex/tasks/task_e_68aab86cda4483288fd79da0cd64873b