### PR TITLE
docs: clarify exported APIs

### DIFF
--- a/actor/dispatcher.go
+++ b/actor/dispatcher.go
@@ -1,7 +1,10 @@
 package actor
 
+// Dispatcher schedules work for actors and reports processing throughput.
 type Dispatcher interface {
+	// Schedule enqueues the provided function for execution.
 	Schedule(fn func())
+	// Throughput returns the number of messages processed per scheduling pass.
 	Throughput() int
 }
 
@@ -9,14 +12,17 @@ type goroutineDispatcher int
 
 var _ Dispatcher = goroutineDispatcher(0)
 
+// Schedule executes the function asynchronously on a new goroutine.
 func (goroutineDispatcher) Schedule(fn func()) {
 	go fn()
 }
 
+// Throughput returns the number of messages processed per pass for the goroutine dispatcher.
 func (d goroutineDispatcher) Throughput() int {
 	return int(d)
 }
 
+// NewDefaultDispatcher creates a Dispatcher that schedules work on separate goroutines.
 func NewDefaultDispatcher(throughput int) Dispatcher {
 	return goroutineDispatcher(throughput)
 }
@@ -25,14 +31,17 @@ type synchronizedDispatcher int
 
 var _ Dispatcher = synchronizedDispatcher(0)
 
+// Schedule runs the function synchronously on the calling goroutine.
 func (synchronizedDispatcher) Schedule(fn func()) {
 	fn()
 }
 
+// Throughput returns the number of messages processed per pass for the synchronized dispatcher.
 func (d synchronizedDispatcher) Throughput() int {
 	return int(d)
 }
 
+// NewSynchronizedDispatcher creates a Dispatcher that executes work sequentially.
 func NewSynchronizedDispatcher(throughput int) Dispatcher {
 	return synchronizedDispatcher(throughput)
 }

--- a/actor/middleware/opentracing/activespan.go
+++ b/actor/middleware/opentracing/activespan.go
@@ -30,6 +30,8 @@ func setActiveSpan(pid *actor.PID, span opentracing.Span) {
 	activeSpan.Store(pid, span)
 }
 
+// GetActiveSpan returns the span currently associated with the actor context.
+// A new span is started if no active span is found.
 func GetActiveSpan(context actor.Context) opentracing.Span {
 	span := getActiveSpan(context.Self())
 	if span == nil {

--- a/actor/middleware/opentracing/middlewarepropagation.go
+++ b/actor/middleware/opentracing/middlewarepropagation.go
@@ -5,6 +5,7 @@ import (
 	"github.com/asynkron/protoactor-go/actor/middleware/propagator"
 )
 
+// TracingMiddleware sets up spawn, sender, and receiver middlewares that propagate tracing spans.
 func TracingMiddleware() actor.SpawnMiddleware {
 	return propagator.New().
 		WithItselfForwarded().

--- a/actor/middleware/opentracing/receivermiddleware.go
+++ b/actor/middleware/opentracing/receivermiddleware.go
@@ -8,6 +8,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 )
 
+// ReceiverMiddleware extracts spans from incoming messages and sets them as active.
 func ReceiverMiddleware() actor.ReceiverMiddleware {
 	return func(next actor.ReceiverFunc) actor.ReceiverFunc {
 		return func(c actor.ReceiverContext, envelope *actor.MessageEnvelope) {

--- a/actor/middleware/opentracing/sendermiddleware.go
+++ b/actor/middleware/opentracing/sendermiddleware.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 )
 
+// SenderMiddleware injects the current span into outgoing messages.
 func SenderMiddleware() actor.SenderMiddleware {
 	return func(next actor.SenderFunc) actor.SenderFunc {
 		return func(c actor.SenderContext, target *actor.PID, envelope *actor.MessageEnvelope) {

--- a/actor/middleware/opentracing/spawnmiddleware.go
+++ b/actor/middleware/opentracing/spawnmiddleware.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 )
 
+// SpawnMiddleware propagates spans when spawning child actors.
 func SpawnMiddleware() actor.SpawnMiddleware {
 	return func(next actor.SpawnFunc) actor.SpawnFunc {
 		return func(actorSystem *actor.ActorSystem, id string, props *actor.Props, parentContext actor.SpawnerContext) (pid *actor.PID, e error) {

--- a/cluster/cluster_provider.go
+++ b/cluster/cluster_provider.go
@@ -4,9 +4,10 @@ package cluster
 //	BannedMembers []string `json:"blockedMembers"`
 //}
 
+// ClusterProvider integrates the cluster implementation with an underlying membership system.
 type ClusterProvider interface {
-	StartMember(cluster *Cluster) error
-	StartClient(cluster *Cluster) error
-	Shutdown(graceful bool) error
-	// UpdateClusterState(state ClusterState) error
+        StartMember(cluster *Cluster) error
+        StartClient(cluster *Cluster) error
+        Shutdown(graceful bool) error
+        // UpdateClusterState(state ClusterState) error
 }

--- a/cluster/cluster_test_tool/cluster_fixture.go
+++ b/cluster/cluster_test_tool/cluster_fixture.go
@@ -88,7 +88,7 @@ func NewBaseClusterFixture(clusterSize int, opts ...ClusterFixtureOption) *BaseC
 		GetClusterKinds:    func() []*cluster.Kind { return make([]*cluster.Kind, 0) },
 		GetClusterProvider: func() cluster.ClusterProvider { return test.NewTestProvider(test.NewInMemAgent()) },
 		Configure:          func(c *cluster.Config) *cluster.Config { return c },
-		GetIdentityLookup:  func(clusterName string) cluster.IdentityLookup { return disthash.New() },
+                GetIdentityLookup:  func(string) cluster.IdentityLookup { return disthash.New() },
 		OnDeposing:         func() {},
 	}
 	for _, opt := range opts {

--- a/cluster/clusterproviders/automanaged/automanaged.go
+++ b/cluster/clusterproviders/automanaged/automanaged.go
@@ -137,8 +137,8 @@ func (p *AutoManagedProvider) DeregisterMember() error {
 	return nil
 }
 
-// Shutdown set the shutdown to true preventing anymore TTL updates
-func (p *AutoManagedProvider) Shutdown(graceful bool) error {
+// Shutdown set the shutdown to true preventing anymore TTL updates.
+func (p *AutoManagedProvider) Shutdown(_ bool) error {
 	p.shutdownMutex.Lock()
 	defer p.shutdownMutex.Unlock()
 

--- a/cluster/clusterproviders/k8s/k8s_provider.go
+++ b/cluster/clusterproviders/k8s/k8s_provider.go
@@ -132,7 +132,8 @@ func (p *Provider) StartClient(c *cluster.Cluster) error {
 	return nil
 }
 
-func (p *Provider) Shutdown(graceful bool) error {
+// Shutdown stops the provider. The argument is kept for API compatibility.
+func (p *Provider) Shutdown(_ bool) error {
 	if p.shutdown {
 		// we are already shut down or shutting down
 		return nil

--- a/cluster/clusterproviders/zk/zk_provider.go
+++ b/cluster/clusterproviders/zk/zk_provider.go
@@ -163,7 +163,7 @@ func (p *Provider) StartClient(c *cluster.Cluster) error {
 }
 
 // Shutdown deregisters the node and stops background processing.
-func (p *Provider) Shutdown(graceful bool) error {
+func (p *Provider) Shutdown(_ bool) error {
 	p.shutdown = true
 	if !p.deregistered {
 		p.updateLeadership(nil)
@@ -268,8 +268,8 @@ func (p *Provider) addWatcher(ctx context.Context, clusterKey string) (<-chan zk
 	return p.addWatcher(ctx, clusterKey)
 }
 
-func (p *Provider) isChildrenChanged(ctx context.Context, stat *zk.Stat) bool {
-	return stat.Cversion != int32(p.revision)
+func (p *Provider) isChildrenChanged(_ context.Context, stat *zk.Stat) bool {
+        return stat.Cversion != int32(p.revision)
 }
 
 func (p *Provider) _keepWatching(registerSelf bool, stream <-chan zk.Event) error {

--- a/cluster/consensus_check_builder.go
+++ b/cluster/consensus_check_builder.go
@@ -11,9 +11,10 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+// ConsensusCheckDefinition produces a consensus check along with the keys it touches.
 type ConsensusCheckDefinition interface {
-	Check() *ConsensusCheck
-	AffectedKeys() map[string]struct{}
+        Check() *ConsensusCheck
+        AffectedKeys() map[string]struct{}
 }
 
 type consensusValue struct {
@@ -27,12 +28,14 @@ type consensusMemberValue struct {
 	value    uint64
 }
 
+// ConsensusCheckBuilder aggregates value extractors to create a consensus check.
 type ConsensusCheckBuilder struct {
-	getConsensusValues []*consensusValue
-	check              ConsensusChecker
-	logger             *slog.Logger
+        getConsensusValues []*consensusValue
+        check              ConsensusChecker
+        logger             *slog.Logger
 }
 
+// NewConsensusCheckBuilder returns a builder seeded with a single consensus value extractor.
 func NewConsensusCheckBuilder(logger *slog.Logger, key string, getValue func(*anypb.Any) interface{}) *ConsensusCheckBuilder {
 	builder := ConsensusCheckBuilder{
 		getConsensusValues: []*consensusValue{
@@ -132,7 +135,7 @@ func (ccb *ConsensusCheckBuilder) build() func(*GossipState, map[string]empty) (
 		}
 	}
 
-	showLog := func(hasConsensus bool, topologyHash uint64, valueTuples []*consensusMemberValue) {
+        showLog := func(hasConsensus bool, _ uint64, valueTuples []*consensusMemberValue) {
 		if ccb.logger.Enabled(context.TODO(), slog.LevelDebug) {
 			groups := map[string]int{}
 			for _, memberValue := range valueTuples {

--- a/cluster/informer_test.go
+++ b/cluster/informer_test.go
@@ -126,10 +126,10 @@ func TestInformer_SendState(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 
-	sendState := func(memberStateDelta *MemberStateDelta, member *Member) {
-		fmt.Printf("%+v\n", memberStateDelta) //nolint:forbidigo
-		wg.Done()
-	}
+        sendState := func(memberStateDelta *MemberStateDelta, _ *Member) {
+                fmt.Printf("%+v\n", memberStateDelta) //nolint:forbidigo
+                wg.Done()
+        }
 
 	s := &MemberHeartbeat{
 		ActorStatistics: &ActorStatistics{},

--- a/cluster/member_list_test.go
+++ b/cluster/member_list_test.go
@@ -193,7 +193,7 @@ func TestMemberList_getPartitionMember(t *testing.T) {
 		obj.UpdateClusterTopology(members)
 
 		testName := fmt.Sprintf("member*%d", v)
-		t.Run(testName, func(t *testing.T) {
+                t.Run(testName, func(_ *testing.T) {
 			//assert := assert.New(t)
 			//
 			//identity := NewClusterIdentity("name", "kind")

--- a/cluster/member_strategy.go
+++ b/cluster/member_strategy.go
@@ -1,11 +1,12 @@
 package cluster
 
+// MemberStrategy describes how the cluster selects members for routing and partitioning.
 type MemberStrategy interface {
-	GetAllMembers() Members
-	AddMember(member *Member)
-	RemoveMember(member *Member)
-	GetPartition(key string) string
-	GetActivator(senderAddress string) string
+        GetAllMembers() Members
+        AddMember(member *Member)
+        RemoveMember(member *Member)
+        GetPartition(key string) string
+        GetActivator(senderAddress string) string
 }
 
 type simpleMemberStrategy struct {
@@ -14,7 +15,7 @@ type simpleMemberStrategy struct {
 	rdv     *Rendezvous
 }
 
-func newDefaultMemberStrategy(cluster *Cluster, kind string) MemberStrategy {
+func newDefaultMemberStrategy(_ *Cluster, _ string) MemberStrategy {
 	ms := &simpleMemberStrategy{members: make(Members, 0)}
 	ms.rr = NewSimpleRoundRobin(MemberStrategy(ms))
 	ms.rdv = NewRendezvous()
@@ -53,6 +54,6 @@ func (m *simpleMemberStrategy) GetPartition(key string) string {
 	return m.rdv.GetByIdentity(key)
 }
 
-func (m *simpleMemberStrategy) GetActivator(senderAddress string) string {
-	return m.rr.GetByRoundRobin()
+func (m *simpleMemberStrategy) GetActivator(_ string) string {
+        return m.rr.GetByRoundRobin()
 }

--- a/cluster/pid_cache.go
+++ b/cluster/pid_cache.go
@@ -5,16 +5,18 @@ import (
 	cmap "github.com/orcaman/concurrent-map"
 )
 
+// PidCacheValue stores actor PIDs for quick lookups.
 type PidCacheValue struct {
-	cache cmap.ConcurrentMap
+        cache cmap.ConcurrentMap
 }
 
+// NewPidCache constructs a new PID cache.
 func NewPidCache() *PidCacheValue {
-	pidCache := &PidCacheValue{
-		cache: cmap.New(),
-	}
+        pidCache := &PidCacheValue{
+                cache: cmap.New(),
+        }
 
-	return pidCache
+        return pidCache
 }
 
 func key(identity string, kind string) string {
@@ -40,10 +42,10 @@ func (c *PidCacheValue) Set(identity string, kind string, pid *actor.PID) {
 func (c *PidCacheValue) RemoveByValue(identity string, kind string, pid *actor.PID) {
 	k := key(identity, kind)
 
-	c.cache.RemoveCb(k, func(key string, v interface{}, exists bool) bool {
-		if !exists {
-			return false
-		}
+        c.cache.RemoveCb(k, func(_ string, v interface{}, exists bool) bool {
+                if !exists {
+                        return false
+                }
 
 		existing, _ := v.(*actor.PID)
 

--- a/cluster/pubsub_producer_test.go
+++ b/cluster/pubsub_producer_test.go
@@ -202,10 +202,10 @@ func (suite *PubSubBatchingProducerTestSuite) TestCanRetryOnPublishingError() {
 	retries := make([]int, 0, 10)
 	producer := NewBatchingProducer(newMockPublisher(suite.failTimesThenSucceed(3)), "topic",
 		WithBatchingProducerBatchSize(1),
-		WithBatchingProducerOnPublishingError(func(retry int, e error, batch *PubSubBatch) *PublishingErrorDecision {
-			retries = append(retries, retry)
-			return RetryBatchImmediately
-		}))
+                WithBatchingProducerOnPublishingError(func(retry int, _ error, _ *PubSubBatch) *PublishingErrorDecision {
+                        retries = append(retries, retry)
+                        return RetryBatchImmediately
+                }))
 	defer producer.Dispose()
 
 	info, err := producer.Produce(context.Background(), &TestMessage{Number: 1})
@@ -218,9 +218,9 @@ func (suite *PubSubBatchingProducerTestSuite) TestCanRetryOnPublishingError() {
 func (suite *PubSubBatchingProducerTestSuite) TestCanSkipBatchOnPublishingError() {
 	producer := NewBatchingProducer(newMockPublisher(suite.failTimesThenSucceed(1)), "topic",
 		WithBatchingProducerBatchSize(1),
-		WithBatchingProducerOnPublishingError(func(retry int, e error, batch *PubSubBatch) *PublishingErrorDecision {
-			return FailBatchAndContinue
-		}))
+                WithBatchingProducerOnPublishingError(func(_ int, _ error, _ *PubSubBatch) *PublishingErrorDecision {
+                        return FailBatchAndContinue
+                }))
 	defer producer.Dispose()
 
 	t1, err := producer.Produce(context.Background(), &TestMessage{Number: 1})

--- a/ctxext/extensions.go
+++ b/ctxext/extensions.go
@@ -1,19 +1,24 @@
+// Package ctxext provides extension mechanisms for actor contexts.
 package ctxext
 
 import "sync/atomic"
 
+// ContextExtensionID uniquely identifies a ContextExtension.
 type ContextExtensionID int32
 
 var currentContextExtensionID int32
 
+// ContextExtension describes an extension that can be attached to an actor Context.
 type ContextExtension interface {
 	ExtensionID() ContextExtensionID
 }
 
+// ContextExtensions stores registered ContextExtension values.
 type ContextExtensions struct {
 	extensions []ContextExtension
 }
 
+// NewContextExtensions creates an empty ContextExtensions collection.
 func NewContextExtensions() *ContextExtensions {
 	ex := &ContextExtensions{
 		extensions: make([]ContextExtension, 3),
@@ -22,15 +27,18 @@ func NewContextExtensions() *ContextExtensions {
 	return ex
 }
 
+// NextContextExtensionID returns a new unique ContextExtensionID.
 func NextContextExtensionID() ContextExtensionID {
 	id := atomic.AddInt32(&currentContextExtensionID, 1)
 	return ContextExtensionID(id)
 }
 
+// Get retrieves the ContextExtension associated with id.
 func (ex *ContextExtensions) Get(id ContextExtensionID) ContextExtension {
 	return ex.extensions[id]
 }
 
+// Set registers the extension in the collection, growing the slice if needed.
 func (ex *ContextExtensions) Set(extension ContextExtension) {
 	id := int32(extension.ExtensionID())
 	if id >= int32(len(ex.extensions)) {

--- a/eventstream/eventstream.go
+++ b/eventstream/eventstream.go
@@ -1,3 +1,4 @@
+// Package eventstream implements a simple publish-subscribe event stream.
 package eventstream
 
 import (
@@ -5,12 +6,13 @@ import (
 	"sync/atomic"
 )
 
-// Handler defines a callback function that must be pass when subscribing.
+// Handler defines a callback function that must be passed when subscribing.
 type Handler func(interface{})
 
-// Predicate is a function used to filter messages before being forwarded to a subscriber
+// Predicate is a function used to filter messages before being forwarded to a subscriber.
 type Predicate func(evt interface{}) bool
 
+// EventStream is a threadsafe publish-subscribe message bus.
 type EventStream struct {
 	sync.RWMutex
 
@@ -21,7 +23,7 @@ type EventStream struct {
 	counter int32
 }
 
-// Create a new EventStream value and returns it back.
+// NewEventStream creates and returns an EventStream.
 func NewEventStream() *EventStream {
 	es := &EventStream{
 		subscriptions: []*Subscription{},
@@ -30,7 +32,7 @@ func NewEventStream() *EventStream {
 	return es
 }
 
-// Subscribe the given handler to the EventStream
+// Subscribe attaches the given handler to the EventStream.
 func (es *EventStream) Subscribe(handler Handler) *Subscription {
 	sub := &Subscription{
 		handler: handler,
@@ -47,8 +49,8 @@ func (es *EventStream) Subscribe(handler Handler) *Subscription {
 	return sub
 }
 
-// SubscribeWithPredicate creates a new Subscription value and sets a predicate to filter messages passed to
-// the subscriber, it returns a pointer to the Subscription value
+// SubscribeWithPredicate creates a Subscription and sets a predicate to filter messages.
+// It returns a pointer to the Subscription.
 func (es *EventStream) SubscribeWithPredicate(handler Handler, p Predicate) *Subscription {
 	sub := es.Subscribe(handler)
 	sub.p = p
@@ -56,7 +58,7 @@ func (es *EventStream) SubscribeWithPredicate(handler Handler, p Predicate) *Sub
 	return sub
 }
 
-// Unsubscribes the given subscription from the EventStream
+// Unsubscribe removes the subscription from the EventStream.
 func (es *EventStream) Unsubscribe(sub *Subscription) {
 	if sub == nil {
 		return
@@ -87,7 +89,7 @@ func (es *EventStream) Unsubscribe(sub *Subscription) {
 	}
 }
 
-// Publishes the given event to all the subscribers in the stream
+// Publish sends the event to all active subscribers.
 func (es *EventStream) Publish(evt interface{}) {
 	subs := make([]*Subscription, 0, es.Length())
 	es.RLock()
@@ -109,16 +111,16 @@ func (es *EventStream) Publish(evt interface{}) {
 	}
 }
 
-// Returns an integer that represents the current number of subscribers to the stream
+// Length returns the number of subscribers currently in the stream.
 func (es *EventStream) Length() int32 {
 	es.RLock()
 	defer es.RUnlock()
 	return es.counter
 }
 
-// Subscription is returned from the Subscribe function.
+// Subscription represents a registered handler and its state.
 //
-// This value and can be passed to Unsubscribe when the observer is no longer interested in receiving messages
+// It can be passed to Unsubscribe when the observer is no longer interested in receiving messages.
 type Subscription struct {
 	id      int32
 	handler Handler
@@ -126,20 +128,17 @@ type Subscription struct {
 	active  uint32
 }
 
-// Activates the Subscription setting its active flag as 1, if the subscription
-// was already active it returns false, true otherwise
+// Activate sets the Subscription as active. It returns true if the state changed.
 func (s *Subscription) Activate() bool {
 	return atomic.CompareAndSwapUint32(&s.active, 0, 1)
 }
 
-// Deactivates the Subscription setting its active flag as 0, if the subscription
-// was already inactive it returns false, true otherwise
+// Deactivate sets the Subscription as inactive. It returns true if the state changed.
 func (s *Subscription) Deactivate() bool {
 	return atomic.CompareAndSwapUint32(&s.active, 1, 0)
 }
 
-// Returns true if the active flag of the Subscription is set as 1
-// otherwise it returns false
+// IsActive reports whether the Subscription is active.
 func (s *Subscription) IsActive() bool {
 	return atomic.LoadUint32(&s.active) == 1
 }

--- a/extensions/extensions.go
+++ b/extensions/extensions.go
@@ -1,19 +1,24 @@
+// Package extensions provides registration and lookup of actor extensions.
 package extensions
 
 import "sync/atomic"
 
+// ExtensionID uniquely identifies a registered Extension.
 type ExtensionID int32
 
 var currentID int32 //nolint:gochecknoglobals
 
+// Extension defines a feature that can be plugged into the actor system.
 type Extension interface {
 	ExtensionID() ExtensionID
 }
 
+// Extensions holds registered Extension instances.
 type Extensions struct {
 	extensions []Extension
 }
 
+// NewExtensions creates an empty Extensions collection.
 func NewExtensions() *Extensions {
 	ex := &Extensions{
 		extensions: make([]Extension, 100),
@@ -22,16 +27,19 @@ func NewExtensions() *Extensions {
 	return ex
 }
 
+// NextExtensionID returns a new unique ExtensionID.
 func NextExtensionID() ExtensionID {
 	id := atomic.AddInt32(&currentID, 1)
 
 	return ExtensionID(id)
 }
 
+// Get retrieves the Extension associated with the given id.
 func (ex *Extensions) Get(id ExtensionID) Extension {
 	return ex.extensions[id]
 }
 
+// Register stores the extension in the collection using its ExtensionID.
 func (ex *Extensions) Register(extension Extension) {
 	id := extension.ExtensionID()
 	ex.extensions[id] = extension

--- a/internal/core/debug.go
+++ b/internal/core/debug.go
@@ -1,3 +1,4 @@
+// Package core contains internal debugging helpers for Proto.Actor.
 package core
 
 import (
@@ -6,6 +7,7 @@ import (
 	"strings"
 )
 
+// IdentifyPanic returns a concise location for the current panic.
 func IdentifyPanic() string {
 	var name, file string
 	var line int

--- a/metrics/actor_metrics.go
+++ b/metrics/actor_metrics.go
@@ -1,5 +1,6 @@
 // Copyright (C) 2017 - 2024 Asynkron.se <http://www.asynkron.se>
 
+// Package metrics exposes instrumentation helpers for Proto.Actor.
 package metrics
 
 import (
@@ -10,8 +11,10 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+// LibName identifies the metrics instrumentation library.
 const LibName string = "protoactor"
 
+// ActorMetrics groups the metric instruments used by actors.
 type ActorMetrics struct {
 	// Actors
 	ActorFailureCount           metric.Int64Counter

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -8,8 +8,10 @@ import (
 	"sync"
 )
 
+// InternalActorMetrics is the key under which builtin actor metrics are registered.
 const InternalActorMetrics string = "internal.actor.metrics"
 
+// ProtoMetrics manages metric instruments for actors.
 type ProtoMetrics struct {
 	mu           sync.Mutex
 	actorMetrics *ActorMetrics
@@ -17,6 +19,7 @@ type ProtoMetrics struct {
 	logger       *slog.Logger
 }
 
+// NewProtoMetrics constructs a ProtoMetrics instance and registers default instruments.
 func NewProtoMetrics(logger *slog.Logger) *ProtoMetrics {
 	protoMetrics := ProtoMetrics{
 		actorMetrics: NewActorMetrics(logger),
@@ -28,8 +31,10 @@ func NewProtoMetrics(logger *slog.Logger) *ProtoMetrics {
 	return &protoMetrics
 }
 
+// Instruments returns the default ActorMetrics instance.
 func (pm *ProtoMetrics) Instruments() *ActorMetrics { return pm.actorMetrics }
 
+// Register associates the provided metrics instance with the given key.
 func (pm *ProtoMetrics) Register(key string, instance *ActorMetrics) {
 	pm.mu.Lock()
 	defer pm.mu.Unlock()
@@ -44,6 +49,7 @@ func (pm *ProtoMetrics) Register(key string, instance *ActorMetrics) {
 	pm.knownMetrics[key] = instance
 }
 
+// Get retrieves the metrics instance registered under key, or nil if none exist.
 func (pm *ProtoMetrics) Get(key string) *ActorMetrics {
 	metrics, ok := pm.knownMetrics[key]
 	if !ok {

--- a/stream/typed.go
+++ b/stream/typed.go
@@ -1,26 +1,32 @@
+// Package stream bridges actors with Go channels.
 package stream
 
 import "github.com/asynkron/protoactor-go/actor"
 
+// TypedStream converts actor messages of type T into a channel.
 type TypedStream[T any] struct {
 	c           chan T
 	pid         *actor.PID
 	actorSystem *actor.ActorSystem
 }
 
+// C returns the underlying receive-only channel for messages of type T.
 func (s *TypedStream[T]) C() <-chan T {
 	return s.c
 }
 
+// PID returns the PID of the backing actor.
 func (s *TypedStream[T]) PID() *actor.PID {
 	return s.pid
 }
 
+// Close stops the backing actor and closes the channel.
 func (s *TypedStream[T]) Close() {
 	s.actorSystem.Root.Stop(s.pid)
 	close(s.c)
 }
 
+// NewTypedStream spawns an actor that forwards messages of type T to a channel.
 func NewTypedStream[T any](actorSystem *actor.ActorSystem) *TypedStream[T] {
 	c := make(chan T)
 

--- a/stream/untyped.go
+++ b/stream/untyped.go
@@ -2,25 +2,30 @@ package stream
 
 import "github.com/asynkron/protoactor-go/actor"
 
+// UntypedStream converts all actor messages into a channel of empty interface.
 type UntypedStream struct {
 	c           chan interface{}
 	pid         *actor.PID
 	actorSystem *actor.ActorSystem
 }
 
+// C returns the underlying receive-only channel.
 func (s *UntypedStream) C() <-chan interface{} {
 	return s.c
 }
 
+// PID returns the PID of the backing actor.
 func (s *UntypedStream) PID() *actor.PID {
 	return s.pid
 }
 
+// Close stops the backing actor and closes the channel.
 func (s *UntypedStream) Close() {
 	s.actorSystem.Root.Stop(s.pid)
 	close(s.c)
 }
 
+// NewUntypedStream spawns an actor that forwards all messages to a channel.
 func NewUntypedStream(actorSystem *actor.ActorSystem) *UntypedStream {
 	c := make(chan interface{})
 


### PR DESCRIPTION
## Summary
- document dispatcher interface
- add missing package and API comments across core packages

## Testing
- `curl -s localhost:8500/v1/status/leader`
- `make lint`
- `go vet ./...`
- `go test ./actor/... -count=1`
- `go test ./cluster/... -count=1`
- `go test ./scheduler -run TestNewTimerScheduler -v`
- `go test ./remote/... -count=1`
- `go test ./persistence/... -count=1`
- `go test ./eventstream/... -count=1`
- `go test ./stream/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68aac9a2b778832885ef285d28c71439