### PR TITLE
chore: reduce lint warnings

### DIFF
--- a/actor/middleware/opentelemetry/sendermiddleware.go
+++ b/actor/middleware/opentelemetry/sendermiddleware.go
@@ -9,6 +9,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// SenderMiddleware injects the active span context into outbound messages.
 func SenderMiddleware() actor.SenderMiddleware {
 	return func(next actor.SenderFunc) actor.SenderFunc {
 		return func(c actor.SenderContext, target *actor.PID, envelope *actor.MessageEnvelope) {

--- a/cluster/gossiper.go
+++ b/cluster/gossiper.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
+// DefaultGossipActorName is the default name used for the gossip actor.
 const DefaultGossipActorName string = "gossip"
 
 // GossipUpdate Used to update gossip data when a ClusterTopology event occurs
@@ -33,7 +34,7 @@ type GossipUpdate struct {
 //	type ConsensusChecker[T] func(GossipState, map[string]empty) (bool, T)
 type ConsensusChecker func(*GossipState, map[string]empty) (bool, interface{})
 
-// The Gossiper data structure manages Gossip
+// Gossiper manages gossip data and dissemination within the cluster.
 type Gossiper struct {
 	// The Gossiper Actor Name, defaults to "gossip"
 	GossipActorName string
@@ -68,6 +69,7 @@ func newGossiper(cl *Cluster, opts ...Option) (*Gossiper, error) {
 	return gossiper, nil
 }
 
+// GetState retrieves gossip state for the given key.
 func (g *Gossiper) GetState(key string) (map[string]*GossipKeyValue, error) {
 	if g.throttler() == actor.Open {
 		g.cluster.Logger().Debug("Gossiper getting state", slog.String("key", key), slog.String("gossipPid", g.pid.String()))
@@ -101,7 +103,7 @@ func (g *Gossiper) GetState(key string) (map[string]*GossipKeyValue, error) {
 	return response.State, nil
 }
 
-// SetState Sends fire and forget message to update member state
+// SetState sends a fire-and-forget message to update member state.
 func (g *Gossiper) SetState(gossipStateKey string, value proto.Message) {
 	if g.throttler() == actor.Open {
 		g.cluster.Logger().Info("Gossiper setting state", slog.String("gossipStateKey", gossipStateKey), slog.String("gossipPid", g.pid.String()))
@@ -115,6 +117,7 @@ func (g *Gossiper) SetState(gossipStateKey string, value proto.Message) {
 	g.cluster.ActorSystem.Root.Send(g.pid, &msg)
 }
 
+// SetMapState updates the value for a key within a map state.
 func (g *Gossiper) SetMapState(gossipStateKey string, mapKey string, value proto.Message) {
 	if g.throttler() == actor.Open {
 		g.cluster.Logger().Info("Gossiper setting map state", slog.String("gossipStateKey", gossipStateKey), slog.String("gossipPid", g.pid.String()))
@@ -133,6 +136,7 @@ func (g *Gossiper) SetMapState(gossipStateKey string, mapKey string, value proto
 	g.cluster.ActorSystem.Root.Send(g.pid, &msg)
 }
 
+// GetMapState retrieves a value from a map in the gossip state.
 func (g *Gossiper) GetMapState(gossipStateKey string, mapKey string) *anypb.Any {
 	if g.throttler() == actor.Open {
 		g.cluster.Logger().Info("Gossiper setting map state", slog.String("gossipStateKey", gossipStateKey), slog.String("gossipPid", g.pid.String()))
@@ -158,6 +162,7 @@ func (g *Gossiper) GetMapState(gossipStateKey string, mapKey string) *anypb.Any 
 	return response.Value
 }
 
+// RemoveMapState deletes a key from a gossip map state.
 func (g *Gossiper) RemoveMapState(gossipStateKey string, mapKey string) {
 	if g.throttler() == actor.Open {
 		g.cluster.Logger().Info("Gossiper setting map state", slog.String("gossipStateKey", gossipStateKey), slog.String("gossipPid", g.pid.String()))
@@ -175,6 +180,7 @@ func (g *Gossiper) RemoveMapState(gossipStateKey string, mapKey string) {
 	g.cluster.ActorSystem.Root.Send(g.pid, &msg)
 }
 
+// GetMapKeys returns all keys stored in a map gossip state.
 func (g *Gossiper) GetMapKeys(gossipStateKey string) []string {
 	if g.throttler() == actor.Open {
 		g.cluster.Logger().Info("Gossiper setting map state", slog.String("gossipStateKey", gossipStateKey), slog.String("gossipPid", g.pid.String()))
@@ -204,7 +210,7 @@ func (g *Gossiper) GetMapKeys(gossipStateKey string) []string {
 	return response.MapKeys
 }
 
-// SetStateRequest Sends a Request (that blocks) to update member state
+// SetStateRequest sends a request that blocks to update member state.
 func (g *Gossiper) SetStateRequest(key string, value proto.Message) error {
 	if g.throttler() == actor.Open {
 		g.cluster.Logger().Debug("Gossiper setting state", slog.String("key", key), slog.String("gossipPid", g.pid.String()))
@@ -235,6 +241,7 @@ func (g *Gossiper) SetStateRequest(key string, value proto.Message) error {
 	return nil
 }
 
+// SendState requests the gossip actor to broadcast its current state.
 func (g *Gossiper) SendState() {
 	if g.pid == nil {
 		return
@@ -261,6 +268,7 @@ func (g *Gossiper) RegisterConsensusCheck(key string, getValue func(*anypb.Any) 
 	return consensusHandle
 }
 
+// StartGossiping spawns the gossip actor and begins gossiping.
 func (g *Gossiper) StartGossiping() error {
 	var err error
 	g.cluster.Logger().Info("Starting gossip")
@@ -293,6 +301,7 @@ func (g *Gossiper) StartGossiping() error {
 	return nil
 }
 
+// Shutdown stops the gossip actor and terminates gossiping.
 func (g *Gossiper) Shutdown() {
 	if g.pid == nil {
 		return
@@ -336,6 +345,7 @@ breakLoop:
 	}
 }
 
+// GetActorCount returns the number of actors for each registered kind.
 func (g *Gossiper) GetActorCount() map[string]int64 {
 	m := make(map[string]int64)
 	clusterKinds := g.cluster.GetClusterKinds()

--- a/eventstream/eventstream_test.go
+++ b/eventstream/eventstream_test.go
@@ -54,7 +54,7 @@ func TestEventStream_Subscribe_WithPredicate_IsCalled(t *testing.T) {
 	es := &eventstream.EventStream{}
 	es.SubscribeWithPredicate(
 		func(interface{}) { called = true },
-		func(m interface{}) bool { return true },
+		func(_ interface{}) bool { return true },
 	)
 	es.Publish("")
 
@@ -66,7 +66,7 @@ func TestEventStream_Subscribe_WithPredicate_IsNotCalled(t *testing.T) {
 	es := &eventstream.EventStream{}
 	es.SubscribeWithPredicate(
 		func(interface{}) { called = true },
-		func(m interface{}) bool { return false },
+		func(_ interface{}) bool { return false },
 	)
 	es.Publish("")
 

--- a/internal/queue/mpsc/mpsc_test.go
+++ b/internal/queue/mpsc/mpsc_test.go
@@ -26,7 +26,7 @@ func TestQueue_Empty(t *testing.T) {
 	assert.False(t, q.Empty())
 }
 
-func TestQueue_PushPopOneProducer(t *testing.T) {
+func TestQueue_PushPopOneProducer(_ *testing.T) {
 	expCount := 100
 
 	var wg sync.WaitGroup

--- a/plugin/passivation_test.go
+++ b/plugin/passivation_test.go
@@ -14,9 +14,8 @@ type SmartActor struct {
 	PassivationHolder
 }
 
-func (state *SmartActor) Receive(context actor.Context) {
-	switch context.Message().(type) {
-	}
+func (state *SmartActor) Receive(_ actor.Context) {
+	// no-op
 }
 
 func TestPassivation(t *testing.T) {

--- a/router/routeractor_group_test.go
+++ b/router/routeractor_group_test.go
@@ -51,7 +51,7 @@ func TestGroupRouterActor_Receive_RemoveRoute(t *testing.T) {
 	c := new(mockContext)
 	c.On("Message").Return(&RemoveRoutee{PID: p1})
 	c.On("Unwatch", p1).
-		Run(func(args mock.Arguments) {
+		Run(func(mock.Arguments) {
 		}).Once()
 
 	state.On("GetRoutees").Return(actor.NewPIDSet(p1, p2))

--- a/testkit/testmailboxstats_test.go
+++ b/testkit/testmailboxstats_test.go
@@ -12,7 +12,7 @@ import (
 func TestMailboxStatsCapturesMessages(t *testing.T) {
 	system := actor.NewActorSystem()
 	stats := NewTestMailboxStats(func(msg interface{}) bool { return msg == "hi" })
-	props := actor.PropsFromFunc(func(ctx actor.Context) {}, actor.WithMailbox(actor.Unbounded(stats)))
+	props := actor.PropsFromFunc(func(actor.Context) {}, actor.WithMailbox(actor.Unbounded(stats)))
 	pid := system.Root.Spawn(props)
 
 	system.Root.Send(pid, "hi")


### PR DESCRIPTION
## Summary
- add documentation for gossiper methods and constants
- fix additional lint warnings in middleware and tests

## Testing
- `make lint >/tmp/lint.log && tail -n 20 /tmp/lint.log`
- `go test ./cluster/... -count=1 >/tmp/cluster_test.log && tail -n 20 /tmp/cluster_test.log` *(fails: panic in TestVirtualActorContextHasClusterIdentity)*
- `go test ./scheduler -run TestNewTimerScheduler -v`
- `go test ./remote/... -count=1`
- `go test ./persistence/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68aaea05efb48328bfe53afa5c836268