### PR TITLE
refactor: improve variable naming in core packages

### DIFF
--- a/actor/deadletter.go
+++ b/actor/deadletter.go
@@ -51,9 +51,9 @@ func NewDeadLetter(actorSystem *ActorSystem) *deadLetterProcess {
 	// This can happen if one actor tries to Watch a PID, while another thread sends a Stop message.
 	actorSystem.EventStream.Subscribe(func(msg interface{}) {
 		if deadLetter, ok := msg.(*DeadLetterEvent); ok {
-			if m, ok := deadLetter.Message.(*Watch); ok {
+			if watchMsg, ok := deadLetter.Message.(*Watch); ok {
 				// we know that this is a local actor since we get it on our own event stream, thus the address is not terminated
-				m.Watcher.sendSystemMessage(actorSystem, &Terminated{
+				watchMsg.Watcher.sendSystemMessage(actorSystem, &Terminated{
 					Who: deadLetter.PID,
 					Why: TerminatedReason_NotFound,
 				})

--- a/cluster/clusterproviders/automanaged/automanaged.go
+++ b/cluster/clusterproviders/automanaged/automanaged.go
@@ -270,12 +270,12 @@ func (p *AutoManagedProvider) checkNodes() ([]*NodeModel, error) {
 	allNodes := make([]*NodeModel, len(p.hosts))
 	g, _ := errgroup.WithContext(context.Background())
 
-	for indice, nodeHost := range p.hosts {
-		idx, el := indice, nodeHost // https://golang.org/doc/faq#closures_and_goroutines
+	for idx, host := range p.hosts {
+		idx, host := idx, host // https://golang.org/doc/faq#closures_and_goroutines
 
 		// Calling go funcs to execute the node check
 		g.Go(func() error {
-			url := fmt.Sprintf("http://%s/_health", el)
+			url := fmt.Sprintf("http://%s/_health", host)
 			req, err := http.NewRequest("GET", url, nil)
 			if err != nil {
 				p.cluster.Logger().Error("Couldn't request node health status", slog.Any("error", err), slog.String("autoManMemberUrl", url))
@@ -291,7 +291,7 @@ func (p *AutoManagedProvider) checkNodes() ([]*NodeModel, error) {
 			defer resp.Body.Close() // nolint: errcheck
 
 			if resp.StatusCode != http.StatusOK {
-				err = fmt.Errorf("non 200 status returned: %d - from node: %s", resp.StatusCode, el)
+				err = fmt.Errorf("non 200 status returned: %d - from node: %s", resp.StatusCode, host)
 				p.cluster.Logger().Error("Bad response from the node health status", slog.Any("error", err), slog.String("autoManMemberUrl", url))
 				return err
 			}
@@ -299,7 +299,7 @@ func (p *AutoManagedProvider) checkNodes() ([]*NodeModel, error) {
 			var node *NodeModel
 			err = json.NewDecoder(resp.Body).Decode(&node)
 			if err != nil {
-				err = fmt.Errorf("could not deserialize response: %v - from node: %s", resp, el)
+				err = fmt.Errorf("could not deserialize response: %v - from node: %s", resp, host)
 				p.cluster.Logger().Error("Bad data from the node health status", slog.Any("error", err), slog.String("autoManMemberUrl", url))
 				return err
 			}

--- a/remote/endpoint_reader.go
+++ b/remote/endpoint_reader.go
@@ -103,10 +103,10 @@ func (s *endpointReader) Receive(stream Remoting_ReceiveServer) error {
 }
 
 func (s *endpointReader) OnConnectRequest(stream Remoting_ReceiveServer, c *ConnectRequest) (bool, error) {
-	switch tt := c.ConnectionType.(type) {
+	switch connType := c.ConnectionType.(type) {
 	case *ConnectRequest_ServerConnection:
 		{
-			sc := tt.ServerConnection
+			sc := connType.ServerConnection
 			s.onServerConnection(stream, sc)
 		}
 	case *ConnectRequest_ClientConnection:

--- a/testkit/testprobe.go
+++ b/testkit/testprobe.go
@@ -17,14 +17,14 @@ type messageAndSender struct {
 // TestProbe is an actor used in tests to intercept and assert on messages.
 // It stores every incoming message along with its sender.
 type TestProbe struct {
-	ch     chan messageAndSender
-	ctx    actor.Context
-	sender *actor.PID
+	mailbox chan messageAndSender
+	ctx     actor.Context
+	sender  *actor.PID
 }
 
 // NewTestProbe creates a new TestProbe instance.
 func NewTestProbe() *TestProbe {
-	return &TestProbe{ch: make(chan messageAndSender, 100)}
+	return &TestProbe{mailbox: make(chan messageAndSender, 100)}
 }
 
 // Receive implements actor.Actor. It records all messages after initialization.
@@ -33,7 +33,7 @@ func (tp *TestProbe) Receive(ctx actor.Context) {
 	case *actor.Started:
 		tp.ctx = ctx
 	default:
-		tp.ch <- messageAndSender{message: ctx.Message(), sender: ctx.Sender()}
+		tp.mailbox <- messageAndSender{message: ctx.Message(), sender: ctx.Sender()}
 	}
 }
 
@@ -54,7 +54,7 @@ func (tp *TestProbe) ExpectNoMessage(timeAllowed time.Duration) error {
 		timeAllowed = time.Second
 	}
 	select {
-	case m := <-tp.ch:
+	case m := <-tp.mailbox:
 		return fmt.Errorf("waited %v and received message of type %T", timeAllowed, m.message)
 	case <-time.After(timeAllowed):
 		return nil
@@ -67,7 +67,7 @@ func (tp *TestProbe) GetNextMessage(timeAllowed time.Duration) (interface{}, err
 		timeAllowed = time.Second
 	}
 	select {
-	case m := <-tp.ch:
+	case m := <-tp.mailbox:
 		tp.sender = m.sender
 		return m.message, nil
 	case <-time.After(timeAllowed):
@@ -130,7 +130,7 @@ func FishForMessage[T any](tp *TestProbe, when func(T) bool, timeAllowed time.Du
 	for time.Now().Before(deadline) {
 		remaining := time.Until(deadline)
 		select {
-		case m := <-tp.ch:
+		case m := <-tp.mailbox:
 			if typed, ok := m.message.(T); ok && when(typed) {
 				tp.sender = m.sender
 				return typed, nil


### PR DESCRIPTION
## Summary
- rename internal variables in deadletter watcher for clarity
- use idiomatic names in automanaged cluster provider
- clarify connection type handling in remote endpoint reader
- use descriptive mailbox naming in test probe

## Testing
- `curl -s localhost:8500/v1/status/leader`
- `go test ./actor/... -count=1`
- `go test ./cluster/... -count=1` *(fails: TestVirtualActorContextHasClusterIdentity)*
- `go test ./scheduler -run TestNewTimerScheduler -v`
- `go test ./remote/... -count=1`
- `go test ./persistence/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68abfdf281e48328a2515435b77ea040