### PR TITLE
cache message type strings

### DIFF
--- a/actor/messagetype.go
+++ b/actor/messagetype.go
@@ -1,6 +1,18 @@
 package actor
 
-import "reflect"
+import (
+	"reflect"
+	"sync"
+)
+
+// messageTypeCache stores string representations for message types keyed by
+// reflect.Type. It avoids repeated reflection-based string conversions.
+var messageTypeCache sync.Map // map[reflect.Type]cachedMessageType
+
+type cachedMessageType struct {
+	full string
+	name string
+}
 
 // MessageType returns the full type name of the given message, including any
 // pointer prefix. It is typically used in logging where the exact Go type is
@@ -9,7 +21,12 @@ func MessageType(msg interface{}) string {
 	if msg == nil {
 		return "<nil>"
 	}
-	return reflect.TypeOf(msg).String()
+	t := reflect.TypeOf(msg)
+	if v, ok := messageTypeCache.Load(t); ok {
+		return v.(cachedMessageType).full
+	}
+	c := cacheMessageType(t)
+	return c.full
 }
 
 // MessageName returns the message type name without a leading pointer prefix.
@@ -20,8 +37,19 @@ func MessageName(msg interface{}) string {
 		return "<nil>"
 	}
 	t := reflect.TypeOf(msg)
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
+	if v, ok := messageTypeCache.Load(t); ok {
+		return v.(cachedMessageType).name
 	}
-	return t.String()
+	c := cacheMessageType(t)
+	return c.name
+}
+
+// cacheMessageType computes and stores string representations for a reflect.Type.
+func cacheMessageType(t reflect.Type) cachedMessageType {
+	c := cachedMessageType{full: t.String(), name: t.String()}
+	if t.Kind() == reflect.Ptr {
+		c.name = t.Elem().String()
+	}
+	messageTypeCache.Store(t, c)
+	return c
 }


### PR DESCRIPTION
## Summary
- cache string representations of message types
- avoid repeated reflection in MessageType and MessageName

## Testing
- `go test ./actor/... -count=1`
- `make lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac045beb148328a699f5a10ed1832c