### PR TITLE
Validate serializer ID range before serialization

### DIFF
--- a/remote/serializer.go
+++ b/remote/serializer.go
@@ -1,5 +1,7 @@
 package remote
 
+import "fmt"
+
 var (
 	// DefaultSerializerID is used when no specific serializer is requested.
 	DefaultSerializerID int32
@@ -24,12 +26,18 @@ type Serializer interface {
 }
 
 // Serialize encodes a message using the specified serializer.
+// An error is returned if the serializerID is out of range or serialization fails.
 func Serialize(message interface{}, serializerID int32) ([]byte, string, error) {
-	res, err := serializers[serializerID].Serialize(message)
+	index := int(serializerID)
+	if index < 0 || index >= len(serializers) {
+		return nil, "", fmt.Errorf("serializerID %d out of range", serializerID)
+	}
+
+	res, err := serializers[index].Serialize(message)
 	if err != nil {
 		return nil, "", err
 	}
-	typeName, err := serializers[serializerID].GetTypeName(message)
+	typeName, err := serializers[index].GetTypeName(message)
 	if err != nil {
 		return nil, "", err
 	}
@@ -37,8 +45,14 @@ func Serialize(message interface{}, serializerID int32) ([]byte, string, error) 
 }
 
 // Deserialize decodes a message using the specified serializer.
+// An error is returned if the serializerID is out of range or deserialization fails.
 func Deserialize(message []byte, typeName string, serializerID int32) (interface{}, error) {
-	return serializers[serializerID].Deserialize(typeName, message)
+	index := int(serializerID)
+	if index < 0 || index >= len(serializers) {
+		return nil, fmt.Errorf("serializerID %d out of range", serializerID)
+	}
+
+	return serializers[index].Deserialize(typeName, message)
 }
 
 // RootSerializable is the root level in-process representation of a message

--- a/remote/serializer_test.go
+++ b/remote/serializer_test.go
@@ -55,3 +55,13 @@ func TestProtobufSerializer_Serialize_PID(t *testing.T) {
 	assert.Equal(t, "actor.PID", typeName)
 	assert.True(t, m.Equal(typed))
 }
+
+func TestSerialize_InvalidSerializerID(t *testing.T) {
+	_, _, err := Serialize("msg", int32(len(serializers)))
+	assert.Error(t, err)
+}
+
+func TestDeserialize_InvalidSerializerID(t *testing.T) {
+	_, err := Deserialize([]byte("{}"), "", int32(len(serializers)))
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- ensure `Serialize` and `Deserialize` verify `serializerID` is within the registered serializer range
- return descriptive errors when `serializerID` is invalid
- add unit tests for invalid serializer IDs

## Testing
- `make lint`
- `go test ./remote/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ac044fba7c8328be8c36dda577dd80