### PR TITLE
Handle unexpected message type in endpoint writer

### DIFF
--- a/remote/endpoint_writer.go
+++ b/remote/endpoint_writer.go
@@ -192,7 +192,12 @@ func (state *endpointWriter) sendEnvelopes(msg []interface{}, ctx actor.Context)
 			return
 		}
 
-		rd, _ := tmp.(*remoteDeliver)
+		// ensure the message is a remoteDeliver before proceeding
+		rd, ok := tmp.(*remoteDeliver)
+		if !ok {
+			state.remote.Logger().Error("EndpointWriter received unknown message", slog.Any("message", tmp))
+			continue
+		}
 
 		if state.stream == nil { // not connected yet since first connection attempt failed and we are waiting for the retry
 			if rd.sender != nil {


### PR DESCRIPTION
## Summary
- guard remote endpoint writer against messages that are not *remoteDeliver

## Testing
- `make lint`
- `go test ./cluster/... -count=1` *(fails: Zookeeper connection refused)*
- `go test ./scheduler -run TestNewTimerScheduler -v`
- `go test ./remote/... -count=1`
- `go test ./persistence/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ac089bda7c8328aa383c70b139077a