### PR TITLE
Log parse errors in etcd node

### DIFF
--- a/cluster/clusterproviders/etcd/node.go
+++ b/cluster/clusterproviders/etcd/node.go
@@ -2,6 +2,7 @@ package etcd
 
 import (
 	"encoding/json"
+	"log/slog"
 	"strconv"
 
 	"github.com/asynkron/protoactor-go/cluster"
@@ -85,8 +86,13 @@ func (n *Node) GetSeq() int {
 	return 0
 }
 
+// strToInt converts a string to an int, logging and returning 0 on failure.
 func strToInt(s string) int {
-	i, _ := strconv.ParseInt(s, 10, 64)
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		slog.Error("failed to parse int", slog.String("value", s), slog.Any("error", err))
+		return 0
+	}
 	return int(i)
 }
 

--- a/cluster/clusterproviders/etcd/node_test.go
+++ b/cluster/clusterproviders/etcd/node_test.go
@@ -1,0 +1,43 @@
+package etcd
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+)
+
+type recordHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *recordHandler) Enabled(ctx context.Context, level slog.Level) bool { return true }
+
+func (h *recordHandler) Handle(ctx context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *recordHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+func (h *recordHandler) WithGroup(name string) slog.Handler       { return h }
+
+func TestStrToIntLogsOnError(t *testing.T) {
+	h := &recordHandler{}
+	logger := slog.New(h)
+	orig := slog.Default()
+	slog.SetDefault(logger)
+	defer slog.SetDefault(orig)
+
+	if v := strToInt("bad"); v != 0 {
+		t.Fatalf("expected 0, got %d", v)
+	}
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.records) == 0 {
+		t.Fatalf("expected log entry for invalid input")
+	}
+}


### PR DESCRIPTION
## Summary
- log and default sequence parsing to 0 when `strconv.ParseInt` fails in the etcd node helper
- test that invalid sequence strings trigger error logging

## Testing
- `curl -s localhost:8500/v1/status/leader`
- `go test ./cluster/clusterproviders/etcd -run TestStrToIntLogsOnError -count=1 -v`
- `go test ./cluster/... -count=1` *(fails: interrupt)*
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac089b1158832898b9f4272a3bcee1