### PR TITLE
log mailbox queue errors

### DIFF
--- a/actor/bounded.go
+++ b/actor/bounded.go
@@ -1,6 +1,8 @@
 package actor
 
 import (
+	"log/slog"
+
 	rbqueue "github.com/Workiva/go-datastructures/queue"
 	"github.com/asynkron/protoactor-go/internal/queue/mpsc"
 )
@@ -13,16 +15,24 @@ type boundedMailboxQueue struct {
 func (q *boundedMailboxQueue) Push(m interface{}) {
 	if q.dropping {
 		if q.userMailbox.Len() > 0 && q.userMailbox.Cap()-1 == q.userMailbox.Len() {
-			_, _ = q.userMailbox.Get()
+			if _, err := q.userMailbox.Get(); err != nil {
+				slog.Default().Error("bounded mailbox failed to drop message", slog.Any("error", err))
+			}
 		}
 	}
 
-	_ = q.userMailbox.Put(m)
+	if err := q.userMailbox.Put(m); err != nil {
+		slog.Default().Error("bounded mailbox failed to enqueue message", slog.Any("error", err))
+	}
 }
 
 func (q *boundedMailboxQueue) Pop() interface{} {
 	if q.userMailbox.Len() > 0 {
-		m, _ := q.userMailbox.Get()
+		m, err := q.userMailbox.Get()
+		if err != nil {
+			slog.Default().Error("bounded mailbox failed to dequeue message", slog.Any("error", err))
+			return nil
+		}
 
 		return m
 	}


### PR DESCRIPTION
## Summary
- capture errors from bounded mailbox queue operations
- log failures to enqueue or dequeue messages

## Testing
- `make lint`
- `go test ./actor/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ac089861f483289a8dacbd53fc2233