### PR TITLE
Handle missing proto types during deserialization

### DIFF
--- a/remote/proto_serializer.go
+++ b/remote/proto_serializer.go
@@ -14,6 +14,7 @@ func newProtoSerializer() *protoSerializer {
 	return &protoSerializer{}
 }
 
+// Serialize converts a protobuf message into its binary form.
 func (p *protoSerializer) Serialize(msg interface{}) ([]byte, error) {
 	if message, ok := msg.(proto.Message); ok {
 		bytes, err := proto.Marshal(message)
@@ -26,15 +27,20 @@ func (p *protoSerializer) Serialize(msg interface{}) ([]byte, error) {
 	return nil, fmt.Errorf("msg must be proto.Message")
 }
 
+// Deserialize creates a protobuf message of the given type and fills it with the provided bytes.
 func (p *protoSerializer) Deserialize(typeName string, bytes []byte) (interface{}, error) {
-	n, _ := protoregistry.GlobalTypes.FindMessageByName(protoreflect.FullName(typeName))
+	mt, err := protoregistry.GlobalTypes.FindMessageByName(protoreflect.FullName(typeName))
+	if err != nil {
+		return nil, err
+	}
 
-	pm := n.New().Interface()
+	pm := mt.New().Interface()
 
-	err := proto.Unmarshal(bytes, pm)
+	err = proto.Unmarshal(bytes, pm)
 	return pm, err
 }
 
+// GetTypeName returns the fully qualified name of a protobuf message.
 func (protoSerializer) GetTypeName(msg interface{}) (string, error) {
 	if message, ok := msg.(proto.Message); ok {
 		typeName := proto.MessageName(message)

--- a/remote/serializer_test.go
+++ b/remote/serializer_test.go
@@ -65,3 +65,9 @@ func TestDeserialize_InvalidSerializerID(t *testing.T) {
 	_, err := Deserialize([]byte("{}"), "", int32(len(serializers)))
 	assert.Error(t, err)
 }
+
+// TestProtobufSerializer_Deserialize_InvalidType ensures an error is returned when the message type is unknown.
+func TestProtobufSerializer_Deserialize_InvalidType(t *testing.T) {
+	_, err := Deserialize([]byte{}, "unknown.Type", 0)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- capture errors from `protoregistry.GlobalTypes.FindMessageByName` before creating a new message
- add a regression test for unknown protobuf type names

## Testing
- `make lint`
- `go test ./cluster/... -count=1` *(fails: test timed out / missing services)*
- `go test ./scheduler -run TestNewTimerScheduler -v`
- `go test ./remote/... -count=1`
- `go test ./persistence/... -count=1`


------
https://chatgpt.com/codex/tasks/task_e_68ac087daf1c8328b229ca722742ef50