### PR TITLE
Avoid dead letter send for unknown system messages

### DIFF
--- a/remote/endpoint_reader.go
+++ b/remote/endpoint_reader.go
@@ -168,7 +168,13 @@ func (s *endpointReader) onMessageBatch(m *MessageBatch) error {
 			}
 			s.remote.edpManager.remoteTerminate(rt)
 		case actor.SystemMessage:
-			ref, _ := s.remote.actorSystem.ProcessRegistry.GetLocal(target.Id)
+			// attempt to get a local process reference
+			ref, ok := s.remote.actorSystem.ProcessRegistry.GetLocal(target.Id)
+			if !ok {
+				// drop the message if the target process does not exist
+				s.remote.Logger().Warn("EndpointReader failed to get local process", slog.String("pid", target.Id))
+				continue
+			}
 			ref.SendSystemMessage(target, msg)
 		default:
 			var header map[string]string


### PR DESCRIPTION
## Summary
- handle missing local processes in endpoint reader by logging and dropping system messages instead of sending to DeadLetter

## Testing
- `go test ./remote/... -count=1`
- `make lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac08814b4c832881bff3e545bce75b