### PR TITLE
feat: Add WithEtcdClient method for etcd provider.

### DIFF
--- a/cluster/clusterproviders/etcd/config.go
+++ b/cluster/clusterproviders/etcd/config.go
@@ -34,10 +34,18 @@ func WithRoleChangedListener(l RoleChangedListener) Option {
 	}
 }
 
+// WithEtcdClient sets a custom etcd client instance.
+func WithEtcdClient(client *clientv3.Client) Option {
+	return func(o *config) {
+		o.client = client
+	}
+}
+
 type config struct {
 	BaseKey     string
 	cfg         clientv3.Config
 	RoleChanged RoleChangedListener
+	client      *clientv3.Client
 }
 
 func defaultConfig() *config {

--- a/cluster/clusterproviders/etcd/etcd_provider.go
+++ b/cluster/clusterproviders/etcd/etcd_provider.go
@@ -56,12 +56,14 @@ func NewWithConfig(baseKey string, cfg clientv3.Config, opts ...Option) (*Provid
 	for _, opt := range opts {
 		opt(c)
 	}
-	client, err := clientv3.New(c.cfg)
-	if err != nil {
-		return nil, err
+	if c.client == nil {
+		var err error
+		if c.client, err = clientv3.New(c.cfg); err != nil {
+			return nil, err
+		}
 	}
 	p := &Provider{
-		client:              client,
+		client:              c.client,
 		keepAliveTTL:        3 * time.Second,
 		retryInterval:       1 * time.Second,
 		baseKey:             c.BaseKey,


### PR DESCRIPTION
Add WithEtcdClient method to allow using a custom etcd client for the cluster's etcd provider.