### PR TITLE
CI: Fix QuickDup workflow on dev

### DIFF
--- a/.github/workflows/quickdup.yml
+++ b/.github/workflows/quickdup.yml
@@ -22,7 +22,7 @@ jobs:
           cache: false
 
       - name: Install QuickDup
-        run: go install github.com/asynkron/Asynkron.QuickDup/cmd/quickdup@v0.2.0
+        run: go install github.com/asynkron/Asynkron.QuickDup/cmd/quickdup@v0.5.2
 
       - name: Run QuickDup
-        run: quickdup -path . -ext .go --exclude "*.pb.go" --github-annotations --git-diff origin/${{ github.base_ref || 'dev' }} --no-cache
+        run: quickdup -path . -ext .go -exclude "*.pb.go" --github-annotations --git-diff origin/${{ github.base_ref || 'dev' }} --no-cache


### PR DESCRIPTION
Fixes failing `QuickDup` CI on `dev` by bumping QuickDup to a version that supports `-exclude`.

CI issue: https://github.com/asynkron/protoactor-go/issues/1275

Notes:
- The workflow was pinned to `v0.2.0` but used `--exclude`, which wasn't supported until later releases.
